### PR TITLE
Ignore error returned from closing r/o file

### DIFF
--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -19,7 +19,7 @@ func ParseFile(path string) ([]*wishlist.Endpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open config: %w", err)
 	}
-	defer f.Close()
+	defer f.Close() // nolint:errcheck
 	return ParseReader(f)
 }
 


### PR DESCRIPTION
Safe to ignore this error, we don't write to this file.