### PR TITLE
fix: parsing ssh config when Host only

### DIFF
--- a/_example/config.ssh_config
+++ b/_example/config.ssh_config
@@ -13,3 +13,7 @@ Host foo
 
 	# all other SSH options are ignored
 	# wildcard Hosts are also ignored
+
+# Having only the Host key also works, it'll be both the endpoint's name and
+#  hostname, using 22 as default port
+Host ssh.example.com

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -4,7 +4,6 @@ package sshconfig
 import (
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strings"
@@ -35,12 +34,12 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 	for _, h := range config.Hosts {
 		for _, pattern := range h.Patterns {
 			name := pattern.String()
-			info := infos[name]
 
 			if strings.Contains(name, "*") {
 				continue // ignore wildcards
 			}
 
+			info := infos[name]
 			for _, n := range h.Nodes {
 				node := strings.TrimSpace(n.String())
 				if node == "" {
@@ -62,8 +61,6 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 					info.User = value
 				case "Port":
 					info.Port = value
-				default:
-					log.Printf("ignoring invalid node type %q on host %q", key, name)
 				}
 			}
 
@@ -73,6 +70,9 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 
 	var endpoints []*wishlist.Endpoint
 	for name, info := range infos {
+		if info.Hostname == "" {
+			info.Hostname = name // Host foo.bar, use foo.bar as name and HostName
+		}
 		if info.Port == "" {
 			info.Port = "22"
 		}

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -49,6 +49,14 @@ func TestParseFile(t *testing.T) {
 				Address: "multi3.foo.local:22",
 				User:    "overridden",
 			},
+			{
+				Name:    "no.hostname",
+				Address: "no.hostname:23231",
+			},
+			{
+				Name:    "only.host",
+				Address: "only.host:22",
+			},
 		}, endpoints)
 	})
 

--- a/sshconfig/testdata/good.ssh_config
+++ b/sshconfig/testdata/good.ssh_config
@@ -32,3 +32,8 @@ Host multiple2
 Host multiple3
   HostName multi3.foo.local
   User overridden
+
+Host no.hostname
+  Port 23231
+
+Host only.host


### PR DESCRIPTION
```
Host ssh.foo.bar
```

will now evaluate to 

```yaml
- name: ssh.foo.bar
  address: ssh.foo.bar:22
```

also removed a log and improved the example a bit.