### PR TITLE
Verifies if the selected item exists

### DIFF
--- a/wishlist.go
+++ b/wishlist.go
@@ -60,7 +60,11 @@ func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		if key.Matches(msg, enter) {
-			m.handoff = m.list.SelectedItem().(*Endpoint)
+			var selectedItem = m.list.SelectedItem()
+			if selectedItem == nil {
+				return m, nil
+			}
+			m.handoff = selectedItem.(*Endpoint)
 			return m, tea.Quit
 		}
 	case tea.WindowSizeMsg:


### PR DESCRIPTION
#### What does this PR do?
Adds a small check to avoid an exception that crashes the client when hitting enter when no items are available.

https://user-images.githubusercontent.com/1270156/149637506-be1da8f1-47ac-41d9-878f-5974006539da.mp4

An edge case, yes, but figured that avoids the crash and the client being disconnected, which provides a better UX overall.

#### How should this be manually tested?
With the patch, run the server, connect with a client and hit enter. It should not raise an exception neither the client should be disconnected.

#### Any background context you want to provide?
Complete log of the panic.

```shell
2022/01/15 22:00:06 Using config from /etc/ssh/ssh_config
2022/01/15 22:00:06 Starting SSH server for list on ssh://0.0.0.0:2222
2022/01/15 22:00:08 kinduff connect 127.0.0.1:38484 false [] xterm-256color 44 29
Caught panic:

interface conversion: list.Item is nil, not *wishlist.Endpoint

Restoring terminal...

goroutine 36 [running]:
runtime/debug.Stack()
	/usr/lib/go/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
	/usr/lib/go/src/runtime/debug/stack.go:16 +0x19
github.com/charmbracelet/bubbletea.(*Program).StartReturningModel.func3()
	/home/kinduff/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.19.3/tea.go:350 +0x95
panic({0x661a00, 0xc00008f2c0})
	/usr/lib/go/src/runtime/panic.go:1047 +0x266
github.com/charmbracelet/wishlist.(*listModel).Update(0xc0001f4900, {0x6814a0, 0xc00008f290})
	/home/kinduff/www/wishlist/wishlist.go:63 +0x345
github.com/charmbracelet/bubbletea.(*Program).StartReturningModel(0xc0001a6200)
	/home/kinduff/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.19.3/tea.go:534 +0x139c
github.com/charmbracelet/bubbletea.(*Program).Start(...)
	/home/kinduff/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.19.3/tea.go:543
github.com/charmbracelet/wishlist.listingMiddleware.func1.1({0x704f70, 0xc0001b4000})
	/home/kinduff/www/wishlist/middleware.go:67 +0x345
github.com/charmbracelet/wishlist.cmdsMiddleware.func1.1({0x704f70, 0xc0001b4000})
	/home/kinduff/www/wishlist/middleware.go:27 +0xef
github.com/charmbracelet/wish/logging.Middleware.func1.1({0x704f70, 0xc0001b4000})
	/home/kinduff/go/pkg/mod/github.com/charmbracelet/wish@v0.1.2/logging/logging.go:22 +0x2af
github.com/charmbracelet/wish/activeterm.Middleware.func1.1({0x704f70, 0xc0001b4000})
	/home/kinduff/go/pkg/mod/github.com/charmbracelet/wish@v0.1.2/activeterm/activeterm.go:21 +0x4d
github.com/gliderlabs/ssh.(*session).handleRequests.func1()
	/home/kinduff/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.3/session.go:262 +0x2d
created by github.com/gliderlabs/ssh.(*session).handleRequests
	/home/kinduff/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.3/session.go:261 +0x514
2022/01/15 22:00:08 127.0.0.1:38484 disconnect 392.756725ms
```