### PR TITLE
feat: add a --local flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ wishlist.yaml
 .wishlist
 dist
 wishlist.log
+cover.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 wishlist.yaml
 .wishlist
 dist
+wishlist.log

--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ You can also use the `wishlist` CLI to list and connect to servers in your `~/.s
 
 ### CLI
 
+#### Remote
+
 If you just want a directory of existing servers, you can use the `wishlist` CLI and a YAML config file. You can also just run it without any arguments to list the servers in your `~/.ssh/config`.
 Check the [example config file](/_example/config.yaml) file as well as `wishlist --help` for details.
+
+#### Local
+
+If you want to explore your own local servers, you can simply run `wishlist --local` to be presented with a the UI filled with your `~/.ssh/config` hosts.
 
 ### Library
 

--- a/client.go
+++ b/client.go
@@ -1,135 +1,13 @@
 package wishlist
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log"
-	"os"
-	"os/user"
-	"path/filepath"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/muesli/termenv"
 	gossh "golang.org/x/crypto/ssh"
-	"golang.org/x/term"
 )
-
-type remoteClient struct {
-	session ssh.Session
-	stdin   io.Reader
-}
-
-func (c *remoteClient) Connect(e *Endpoint) error {
-	resetPty(c.session)
-
-	method, closers, err := remoteBestAuthMethod(c.session)
-	defer closers.close()
-	if err != nil {
-		return fmt.Errorf("failed to find an auth method: %w", err)
-	}
-
-	conf := &gossh.ClientConfig{
-		User:            firstNonEmpty(e.User, c.session.User()),
-		HostKeyCallback: hostKeyCallback(e, ".wishlist/known_hosts"),
-		Auth:            []gossh.AuthMethod{method},
-	}
-
-	session, cl, err := createSession(conf, e)
-	defer cl.close()
-	if err != nil {
-		return fmt.Errorf("failed to create session: %w", err)
-	}
-
-	log.Printf("%s connect to %q, %s", c.session.User(), e.Name, c.session.RemoteAddr().String())
-
-	session.Stdout = c.session
-	session.Stderr = c.session.Stderr()
-	session.Stdin = c.stdin
-
-	pty, winch, _ := c.session.Pty()
-	w := pty.Window
-	if err := session.RequestPty(pty.Term, w.Height, w.Width, nil); err != nil {
-		return fmt.Errorf("failed to request pty: %w", err)
-	}
-
-	done := make(chan bool, 1)
-	defer func() { done <- true }()
-
-	go c.notifyWindowChanges(session, done, winch)
-
-	return shellAndWait(session)
-}
-
-func (c *remoteClient) notifyWindowChanges(session *gossh.Session, done <-chan bool, winch <-chan ssh.Window) {
-	for {
-		select {
-		case <-done:
-			return
-		case w := <-winch:
-			if w.Height == 0 && w.Width == 0 {
-				// this only happens if the session is already dead, make sure there are no leftovers
-				return
-			}
-			if err := session.WindowChange(w.Height, w.Width); err != nil {
-				log.Println("failed to notify window change:", err)
-				return
-			}
-		}
-	}
-}
-
-type localClient struct{}
-
-func (c *localClient) Connect(e *Endpoint) error {
-	resetPty(os.Stdout)
-	defer resetPty(os.Stdout)
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user home dir: %w", err)
-	}
-	user, err := user.Current()
-
-	if err != nil {
-		return fmt.Errorf("failed to get current username: %w", err)
-	}
-
-	methods, err := tryUserKeys(home)
-	if err != nil {
-		return fmt.Errorf("failed to get user keys: %w", err)
-	}
-	conf := &gossh.ClientConfig{
-		User:            firstNonEmpty(e.User, user.Username),
-		Auth:            methods,
-		HostKeyCallback: hostKeyCallback(e, filepath.Join(home, ".ssh/known_hosts")),
-	}
-
-	session, cls, err := createSession(conf, e)
-	defer cls.close()
-	if err != nil {
-		return fmt.Errorf("failed to create sessio: %w", err)
-	}
-
-	session.Stdout = os.Stdout
-	session.Stderr = os.Stderr
-	session.Stdin = os.Stdin
-
-	w, h, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		return fmt.Errorf("failed to get term size: %w", err)
-	}
-
-	if err := session.RequestPty(os.Getenv("$TERM"), h, w, nil); err != nil {
-		return fmt.Errorf("failed to request a pty: %w", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go c.notifyWindowChanges(ctx, session)
-
-	return shellAndWait(session)
-}
 
 func createSession(conf *gossh.ClientConfig, e *Endpoint) (*gossh.Session, closers, error) {
 	var cl closers

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
+// SSHClient is a SSH client.
 type SSHClient interface {
 	Connect(e *Endpoint) error
 }

--- a/client.go
+++ b/client.go
@@ -2,12 +2,14 @@ package wishlist
 
 import (
 	"fmt"
-	"io"
 	"log"
 
-	"github.com/muesli/termenv"
 	gossh "golang.org/x/crypto/ssh"
 )
+
+type SSHClient interface {
+	Connect(e *Endpoint) error
+}
 
 func createSession(conf *gossh.ClientConfig, e *Endpoint) (*gossh.Session, closers, error) {
 	var cl closers
@@ -54,10 +56,4 @@ func firstNonEmpty(ss ...string) string {
 		}
 	}
 	return ""
-}
-
-func resetPty(w io.Writer) {
-	fmt.Fprint(w, termenv.CSI+termenv.ExitAltScreenSeq)
-	fmt.Fprint(w, termenv.CSI+termenv.ResetSeq+"m")
-	fmt.Fprintf(w, termenv.CSI+termenv.EraseDisplaySeq, 2) // nolint:gomnd
 }

--- a/client.go
+++ b/client.go
@@ -12,21 +12,21 @@ type SSHClient interface {
 	Connect(e *Endpoint) error
 }
 
-func createSession(conf *gossh.ClientConfig, e *Endpoint) (*gossh.Session, closers, error) {
+func createSession(conf *gossh.ClientConfig, e *Endpoint) (*gossh.Session, *gossh.Client, closers, error) {
 	var cl closers
 	conn, err := gossh.Dial("tcp", e.Address, conf)
 	if err != nil {
-		return nil, cl, fmt.Errorf("connection failed: %w", err)
+		return nil, nil, cl, fmt.Errorf("connection failed: %w", err)
 	}
 
 	cl = append(cl, conn.Close)
 
 	session, err := conn.NewSession()
 	if err != nil {
-		return nil, cl, fmt.Errorf("failed to open session: %w", err)
+		return nil, conn, cl, fmt.Errorf("failed to open session: %w", err)
 	}
 	cl = append(cl, session.Close)
-	return session, cl, nil
+	return session, conn, cl, nil
 }
 
 func shellAndWait(session *gossh.Session) error {

--- a/client.go
+++ b/client.go
@@ -1,25 +1,95 @@
 package wishlist
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"os"
+	"os/signal"
 	"os/user"
 	"path/filepath"
+	"syscall"
 
-	"github.com/charmbracelet/keygen"
 	"github.com/gliderlabs/ssh"
 	"github.com/muesli/termenv"
 	gossh "golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
-	"golang.org/x/crypto/ssh/knownhosts"
 	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
-func connectLocal(e *Endpoint) error {
+// TODO: move this elsewhere
+
+type sshClient interface {
+	Connect(*Endpoint) error
+}
+
+type remoteClient struct {
+	session ssh.Session
+	stdin   io.Reader
+}
+
+func (c *remoteClient) Connect(e *Endpoint) error {
+	resetPty(c.session)
+
+	method, closers, err := remoteBestAuthMethod(c.session)
+	defer closers.close()
+	if err != nil {
+		return fmt.Errorf("failed to find an auth method: %w", err)
+	}
+
+	conf := &gossh.ClientConfig{
+		User:            firstNonEmpty(e.User, c.session.User()),
+		HostKeyCallback: hostKeyCallback(e, ".wishlist/known_hosts"),
+		Auth:            []gossh.AuthMethod{method},
+	}
+
+	session, cl, err := createSession(conf, e)
+	defer cl.close()
+	if err != nil {
+		return fmt.Errorf("failed to create session: %w", err)
+	}
+
+	log.Printf("%s connect to %q, %s", c.session.User(), e.Name, c.session.RemoteAddr().String())
+
+	session.Stdout = c.session
+	session.Stderr = c.session.Stderr()
+	session.Stdin = c.stdin
+
+	pty, winch, _ := c.session.Pty()
+	w := pty.Window
+	if err := session.RequestPty(pty.Term, w.Height, w.Width, nil); err != nil {
+		return fmt.Errorf("failed to request pty: %w", err)
+	}
+
+	done := make(chan bool, 1)
+	defer func() { done <- true }()
+
+	go c.notifyWindowChanges(session, done, winch)
+
+	return shellAndWait(session)
+}
+
+func (c *remoteClient) notifyWindowChanges(session *gossh.Session, done <-chan bool, winch <-chan ssh.Window) {
+	for {
+		select {
+		case <-done:
+			return
+		case w := <-winch:
+			if w.Height == 0 && w.Width == 0 {
+				// this only happens if the session is already dead, make sure there are no leftovers
+				return
+			}
+			if err := session.WindowChange(w.Height, w.Width); err != nil {
+				log.Println("failed to notify window change:", err)
+				return
+			}
+		}
+	}
+}
+
+type localClient struct{}
+
+func (c *localClient) Connect(e *Endpoint) error {
 	resetPty(os.Stdout)
 	defer resetPty(os.Stdout)
 
@@ -43,119 +113,65 @@ func connectLocal(e *Endpoint) error {
 		HostKeyCallback: hostKeyCallback(e, filepath.Join(home, ".ssh/known_hosts")),
 	}
 
-	conn, err := gossh.Dial("tcp", e.Address, conf)
+	session, cls, err := createSession(conf, e)
+	defer cls.close()
 	if err != nil {
-		return fmt.Errorf("connection failed: %w", err)
+		return fmt.Errorf("failed to create sessio: %w", err)
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			log.Println("failed to close conn:", err)
-		}
-	}()
-
-	session, err := conn.NewSession()
-	if err != nil {
-		return fmt.Errorf("failed to open session: %w", err)
-	}
-
-	defer func() {
-		if err := session.Close(); err != nil && err != io.EOF {
-			log.Println("failed to close session:", err)
-		}
-	}()
 
 	session.Stdout = os.Stdout
 	session.Stderr = os.Stderr
 	session.Stdin = os.Stdin
 
-	w, h, err := terminal.GetSize(0)
+	w, h, err := terminal.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		return fmt.Errorf("failed to get term size: %w", err)
 	}
 
-	if err := session.RequestPty("xterm-256", h, w, nil); err != nil {
+	if err := session.RequestPty(os.Getenv("$TERM"), h, w, nil); err != nil {
 		return fmt.Errorf("failed to request a pty: %w", err)
 	}
-	// TODO: handle resizes... somehow
-	if err := session.Shell(); err != nil {
-		return fmt.Errorf("failed to start shell: %w", err)
-	}
 
-	if err := session.Wait(); err != nil {
-		return fmt.Errorf("session failed: %w", err)
-	}
-	return nil
-
-}
-
-func resetPty(w io.Writer) {
-	fmt.Fprint(w, termenv.CSI+termenv.ExitAltScreenSeq)
-	fmt.Fprint(w, termenv.CSI+termenv.ResetSeq+"m")
-	fmt.Fprintf(w, termenv.CSI+termenv.EraseDisplaySeq, 2) // nolint:gomnd
-}
-
-func mustConnect(s ssh.Session, e *Endpoint, stdin io.Reader) {
-	if err := connect(s, e, stdin); err != nil {
-		fmt.Fprintf(s, "wishlist: %s\n\r", err.Error())
-		_ = s.Exit(1)
-		return // unreachable
-	}
-	fmt.Fprintf(s, "wishlist: closed connection to %q (%s)\n\r", e.Name, e.Address)
-	_ = s.Exit(0)
-}
-
-func connect(prev ssh.Session, e *Endpoint, stdin io.Reader) error {
-	resetPty(prev)
-
-	method, closers, err := authMethod(prev)
-	defer closers.close()
-	if err != nil {
-		return fmt.Errorf("failed to find an auth method: %w", err)
-	}
-
-	conf := &gossh.ClientConfig{
-		User:            firstNonEmpty(e.User, prev.User()),
-		HostKeyCallback: hostKeyCallback(e, ".wishlist/known_hosts"),
-		Auth:            []gossh.AuthMethod{method},
-	}
-
-	conn, err := gossh.Dial("tcp", e.Address, conf)
-	if err != nil {
-		return fmt.Errorf("connection failed: %w", err)
-	}
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGWINCH)
 	defer func() {
-		if err := conn.Close(); err != nil {
-			log.Println("failed to close conn:", err)
+		signal.Stop(sig)
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-sig:
+				w, h, err := term.GetSize(int(os.Stdout.Fd()))
+				if err != nil {
+					log.Println(err)
+				}
+				session.WindowChange(h, w)
+			}
 		}
 	}()
+
+	return shellAndWait(session)
+}
+
+func createSession(conf *gossh.ClientConfig, e *Endpoint) (*gossh.Session, closers, error) {
+	var cl closers
+	conn, err := gossh.Dial("tcp", e.Address, conf)
+	if err != nil {
+		return nil, cl, fmt.Errorf("connection failed: %w", err)
+	}
+
+	cl = append(cl, conn.Close)
 
 	session, err := conn.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to open session: %w", err)
+		return nil, cl, fmt.Errorf("failed to open session: %w", err)
 	}
+	cl = append(cl, session.Close)
+	return session, cl, nil
+}
 
-	log.Printf("%s connect to %q, %s -> %s", prev.User(), e.Name, prev.RemoteAddr().String(), conn.RemoteAddr().String())
-	defer func() {
-		if err := session.Close(); err != nil && err != io.EOF {
-			log.Println("failed to close session:", err)
-		}
-	}()
-
-	session.Stdout = prev
-	session.Stderr = prev.Stderr()
-	session.Stdin = stdin
-
-	pty, winch, _ := prev.Pty()
-	w := pty.Window
-	if err := session.RequestPty(pty.Term, w.Height, w.Width, nil); err != nil {
-		return fmt.Errorf("failed to request pty: %w", err)
-	}
-
-	done := make(chan bool, 1)
-	defer func() { done <- true }()
-
-	go notifyWindowChanges(session, done, winch)
-
+func shellAndWait(session *gossh.Session) error {
 	if err := session.Shell(); err != nil {
 		return fmt.Errorf("failed to start shell: %w", err)
 	}
@@ -164,24 +180,6 @@ func connect(prev ssh.Session, e *Endpoint, stdin io.Reader) error {
 		return fmt.Errorf("session failed: %w", err)
 	}
 	return nil
-}
-
-func notifyWindowChanges(session *gossh.Session, done <-chan bool, winch <-chan ssh.Window) {
-	for {
-		select {
-		case <-done:
-			return
-		case w := <-winch:
-			if w.Height == 0 && w.Width == 0 {
-				// this only happens if the session is already dead, make sure there are no leftovers
-				return
-			}
-			if err := session.WindowChange(w.Height, w.Width); err != nil {
-				log.Println("failed to notify window change:", err)
-				return
-			}
-		}
-	}
 }
 
 type closers []func() error
@@ -194,89 +192,6 @@ func (c closers) close() {
 	}
 }
 
-// authMethod returns an auth method.
-//
-// it first tries to use ssh-agent, if that's not available, it creates and uses a new key pair.
-func authMethod(s ssh.Session) (gossh.AuthMethod, closers, error) {
-	method, closers, err := tryAuthAgent(s)
-	if err != nil {
-		return method, closers, err
-	}
-	if method != nil {
-		return method, closers, nil
-	}
-
-	method, err = tryNewKey()
-	return method, closers, err
-}
-
-// tryAuthAgent will try to use an ssh-agent to authenticate.
-func tryAuthAgent(s ssh.Session) (gossh.AuthMethod, closers, error) {
-	_, _ = s.SendRequest("auth-agent-req@openssh.com", true, nil)
-
-	if ssh.AgentRequested(s) {
-		l, err := ssh.NewAgentListener()
-		if err != nil {
-			return nil, nil, err // nolint:wrapcheck
-		}
-		go ssh.ForwardAgentConnections(l, s)
-
-		conn, err := net.Dial(l.Addr().Network(), l.Addr().String())
-		if err != nil {
-			return nil, closers{l.Close}, err // nolint:wrapcheck
-		}
-
-		return gossh.PublicKeysCallback(agent.NewClient(conn).Signers),
-			closers{l.Close, conn.Close},
-			nil
-	}
-
-	fmt.Fprintf(s.Stderr(), "wishlist: ssh agent not available\n\r")
-	return nil, nil, nil
-}
-
-func tryUserKeys(home string) ([]gossh.AuthMethod, error) {
-	var methods []gossh.AuthMethod
-	for _, name := range []string{
-		"id_rsa",
-		"id_ed25519",
-	} {
-		path := filepath.Join(home, ".ssh", name)
-		bts, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		signer, err := gossh.ParsePrivateKey(bts)
-		if err != nil {
-			return methods, err
-		}
-		log.Printf("using %q", path)
-		methods = append(methods, gossh.PublicKeys(signer))
-	}
-
-	return methods, nil
-}
-
-// tryNewKey will create a .wishlist/client_ed25519 keypair if one does not exist.
-// It will return an auth method that uses the keypair if it exist or is successfully created.
-func tryNewKey() (gossh.AuthMethod, error) {
-	key, err := keygen.New(".wishlist", "client", nil, keygen.Ed25519)
-	if err != nil {
-		return nil, err // nolint:wrapcheck
-	}
-
-	signer, err := gossh.ParsePrivateKey(key.PrivateKeyPEM)
-	if err != nil {
-		return nil, err // nolint:wrapcheck
-	}
-
-	if key.IsKeyPairExists() {
-		return gossh.PublicKeys(signer), nil
-	}
-
-	return gossh.PublicKeys(signer), key.WriteKeys()
-}
-
 func firstNonEmpty(ss ...string) string {
 	for _, s := range ss {
 		if s != "" {
@@ -286,35 +201,8 @@ func firstNonEmpty(ss ...string) string {
 	return ""
 }
 
-// hostKeyCallback returns a callback that will be used to verify the host key.
-//
-// it creates a file in the given path, and uses that to verify hosts and keys.
-// if the host does not exist there, it adds it so its available next time, as plain old `ssh` does.
-func hostKeyCallback(e *Endpoint, path string) gossh.HostKeyCallback {
-	return func(hostname string, remote net.Addr, key gossh.PublicKey) error {
-		kh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600) // nolint:gomnd
-		if err != nil {
-			return fmt.Errorf("failed to open known_hosts: %w", err)
-		}
-		defer func() { _ = kh.Close() }()
-
-		callback, err := knownhosts.New(kh.Name())
-		if err != nil {
-			return fmt.Errorf("failed to check known_hosts: %w", err)
-		}
-
-		if err := callback(hostname, remote, key); err != nil {
-			var kerr *knownhosts.KeyError
-			if errors.As(err, &kerr) {
-				if len(kerr.Want) > 0 {
-					return fmt.Errorf("possible man-in-the-middle attack: %w", err)
-				}
-				// if want is empty, it means the host was not in the known_hosts file, so lets add it there.
-				fmt.Fprintln(kh, knownhosts.Line([]string{e.Address}, key))
-				return nil
-			}
-			return fmt.Errorf("failed to check known_hosts: %w", err)
-		}
-		return nil
-	}
+func resetPty(w io.Writer) {
+	fmt.Fprint(w, termenv.CSI+termenv.ExitAltScreenSeq)
+	fmt.Fprint(w, termenv.CSI+termenv.ResetSeq+"m")
+	fmt.Fprintf(w, termenv.CSI+termenv.EraseDisplaySeq, 2) // nolint:gomnd
 }

--- a/client_auth.go
+++ b/client_auth.go
@@ -39,6 +39,9 @@ func remoteBestAuthMethod(s ssh.Session) (gossh.AuthMethod, closers, error) {
 // - an IdentityFile, if there's one set in the endpoint
 // - the local ssh agent, if available
 // - common key filenames under ~/.ssh/
+//
+// If any of the methods fails, it returns an error.
+// It'll return a nil list if none of the methods is available.
 func localBestAuthMethod(e *Endpoint) ([]gossh.AuthMethod, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/client_auth.go
+++ b/client_auth.go
@@ -48,17 +48,16 @@ func localBestAuthMethod(e *Endpoint) ([]gossh.AuthMethod, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user home dir: %w", err)
 	}
-	if e.IdentityFile != "" {
-		return toAuthMethodList(tryIdentityFile(home, e.IdentityFile))
-	}
+	var methods []gossh.AuthMethod
 	if method, err := tryLocalAgent(); err != nil || method != nil {
-		return toAuthMethodList(method, err)
+		methods = append(methods, method)
 	}
-	return tryUserKeys(home)
-}
-
-func toAuthMethodList(m gossh.AuthMethod, err error) ([]gossh.AuthMethod, error) {
-	return []gossh.AuthMethod{m}, err
+	if e.IdentityFile != "" {
+		method, err := tryIdentityFile(home, e.IdentityFile)
+		return append(methods, method), err
+	}
+	keys, err := tryUserKeys(home)
+	return append(methods, keys...), err
 }
 
 // tryLocalAgent checks if there's a local agent at $SSH_AUTH_SOCK and, if so,

--- a/client_auth.go
+++ b/client_auth.go
@@ -77,9 +77,9 @@ func tryNewKey() (gossh.AuthMethod, error) {
 }
 
 // tryUserKeys will try to find id_rsa and id_ed25519 keys in the user $HOME/~.ssh folder.
-// TODO: parse ssh config and get keys from there if any
+// TODO: parse ssh config and get keys from there if any.
 func tryUserKeys(home string) ([]gossh.AuthMethod, error) {
-	var methods []gossh.AuthMethod
+	var methods []gossh.AuthMethod // nolint: prealloc
 	for _, name := range []string{
 		"id_rsa",
 		"id_ed25519",
@@ -91,7 +91,7 @@ func tryUserKeys(home string) ([]gossh.AuthMethod, error) {
 		}
 		signer, err := gossh.ParsePrivateKey(bts)
 		if err != nil {
-			return methods, err
+			return methods, fmt.Errorf("failed to parse private key: %q: %w", path, err)
 		}
 		log.Printf("using %q", path)
 		methods = append(methods, gossh.PublicKeys(signer))

--- a/client_auth.go
+++ b/client_auth.go
@@ -1,0 +1,134 @@
+package wishlist
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/charmbracelet/keygen"
+	"github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// remoteBestAuthMethod returns an auth method.
+//
+// it first tries to use ssh-agent, if that's not available, it creates and uses a new key pair.
+func remoteBestAuthMethod(s ssh.Session) (gossh.AuthMethod, closers, error) {
+	method, closers, err := tryAuthAgent(s)
+	if err != nil {
+		return method, closers, err
+	}
+	if method != nil {
+		return method, closers, nil
+	}
+
+	method, err = tryNewKey()
+	return method, closers, err
+}
+
+// tryAuthAgent will try to use an ssh-agent to authenticate.
+func tryAuthAgent(s ssh.Session) (gossh.AuthMethod, closers, error) {
+	_, _ = s.SendRequest("auth-agent-req@openssh.com", true, nil)
+
+	if ssh.AgentRequested(s) {
+		l, err := ssh.NewAgentListener()
+		if err != nil {
+			return nil, nil, err // nolint:wrapcheck
+		}
+		go ssh.ForwardAgentConnections(l, s)
+
+		conn, err := net.Dial(l.Addr().Network(), l.Addr().String())
+		if err != nil {
+			return nil, closers{l.Close}, err // nolint:wrapcheck
+		}
+
+		return gossh.PublicKeysCallback(agent.NewClient(conn).Signers),
+			closers{l.Close, conn.Close},
+			nil
+	}
+
+	fmt.Fprintf(s.Stderr(), "wishlist: ssh agent not available\n\r")
+	return nil, nil, nil
+}
+
+// tryNewKey will create a .wishlist/client_ed25519 keypair if one does not exist.
+// It will return an auth method that uses the keypair if it exist or is successfully created.
+func tryNewKey() (gossh.AuthMethod, error) {
+	key, err := keygen.New(".wishlist", "client", nil, keygen.Ed25519)
+	if err != nil {
+		return nil, err // nolint:wrapcheck
+	}
+
+	signer, err := gossh.ParsePrivateKey(key.PrivateKeyPEM)
+	if err != nil {
+		return nil, err // nolint:wrapcheck
+	}
+
+	if key.IsKeyPairExists() {
+		return gossh.PublicKeys(signer), nil
+	}
+
+	return gossh.PublicKeys(signer), key.WriteKeys()
+}
+
+// tryUserKeys will try to find id_rsa and id_ed25519 keys in the user $HOME/~.ssh folder.
+// TODO: parse ssh config and get keys from there if any
+func tryUserKeys(home string) ([]gossh.AuthMethod, error) {
+	var methods []gossh.AuthMethod
+	for _, name := range []string{
+		"id_rsa",
+		"id_ed25519",
+	} {
+		path := filepath.Join(home, ".ssh", name)
+		bts, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		signer, err := gossh.ParsePrivateKey(bts)
+		if err != nil {
+			return methods, err
+		}
+		log.Printf("using %q", path)
+		methods = append(methods, gossh.PublicKeys(signer))
+	}
+
+	return methods, nil
+}
+
+// hostKeyCallback returns a callback that will be used to verify the host key.
+//
+// it creates a file in the given path, and uses that to verify hosts and keys.
+// if the host does not exist there, it adds it so its available next time, as plain old `ssh` does.
+func hostKeyCallback(e *Endpoint, path string) gossh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key gossh.PublicKey) error {
+		kh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600) // nolint:gomnd
+		if err != nil {
+			return fmt.Errorf("failed to open known_hosts: %w", err)
+		}
+		defer func() { _ = kh.Close() }()
+
+		callback, err := knownhosts.New(kh.Name())
+		if err != nil {
+			return fmt.Errorf("failed to check known_hosts: %w", err)
+		}
+
+		if err := callback(hostname, remote, key); err != nil {
+			var kerr *knownhosts.KeyError
+			if errors.As(err, &kerr) {
+				if len(kerr.Want) > 0 {
+					return fmt.Errorf("possible man-in-the-middle attack: %w", err)
+				}
+				// if want is empty, it means the host was not in the known_hosts file, so lets add it there.
+				fmt.Fprintln(kh, knownhosts.Line([]string{e.Address}, key))
+				return nil
+			}
+			return fmt.Errorf("failed to check known_hosts: %w", err)
+		}
+		return nil
+	}
+}

--- a/client_auth.go
+++ b/client_auth.go
@@ -111,7 +111,7 @@ func tryUserKeys(home string) ([]gossh.AuthMethod, error) {
 func parsePrivateKey(path string) (gossh.AuthMethod, error) {
 	bts, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read key: %q: %w", path, err)
 	}
 	signer, err := gossh.ParsePrivateKey(bts)
 	if err != nil {

--- a/client_auth.go
+++ b/client_auth.go
@@ -131,7 +131,6 @@ func expand(home, p string) string {
 		return p
 	}
 	return filepath.Join(home, strings.TrimPrefix(p, "~/"))
-
 }
 
 // tryUserKeys will try to find id_rsa and id_ed25519 keys in the user $HOME/~.ssh folder.
@@ -162,7 +161,7 @@ func parsePrivateKey(path string, password []byte) (gossh.AuthMethod, error) {
 	if len(password) == 0 {
 		signer, err = gossh.ParsePrivateKey(bts)
 	} else {
-		signer, err = gossh.ParsePrivateKeyWithPassphrase(bts, []byte(password))
+		signer, err = gossh.ParsePrivateKeyWithPassphrase(bts, password)
 	}
 	if err != nil {
 		pwderr := &gossh.PassphraseMissingError{}

--- a/client_auth.go
+++ b/client_auth.go
@@ -167,7 +167,7 @@ func parsePrivateKey(path string, password []byte) (gossh.AuthMethod, error) {
 	if err != nil {
 		pwderr := &gossh.PassphraseMissingError{}
 		if errors.As(err, &pwderr) {
-			fmt.Printf("Enter the password for %q: ", path) // TODO: why is this not displayed?
+			fmt.Printf("Enter the password for %q: ", path)
 			password, err = term.ReadPassword(int(os.Stdin.Fd()))
 			fmt.Println()
 			if err != nil {

--- a/client_auth.go
+++ b/client_auth.go
@@ -129,7 +129,7 @@ func tryNewKey() (gossh.AuthMethod, error) {
 }
 
 func tryIdendityFiles(e *Endpoint) ([]gossh.AuthMethod, error) {
-	var methods []gossh.AuthMethod
+	methods := make([]gossh.AuthMethod, 0, len(e.IdentityFiles))
 	for _, id := range e.IdentityFiles {
 		method, err := tryIdentityFile(id)
 		if err != nil {
@@ -144,7 +144,7 @@ func tryIdendityFiles(e *Endpoint) ([]gossh.AuthMethod, error) {
 func tryIdentityFile(id string) (gossh.AuthMethod, error) {
 	h, err := home.ExpandPath(id)
 	if err != nil {
-		return nil, err
+		return nil, err // nolint: wrapcheck
 	}
 	return parsePrivateKey(h, nil)
 }

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -13,8 +13,7 @@ import (
 func TestUserKeys(t *testing.T) {
 	fn := func(home string) func(string) (string, error) {
 		return func(s string) (string, error) {
-			t.Log("PATH IS", s)
-			return filepath.Join(home, strings.TrimPrefix(s, "~/")), nil
+			return filepath.Join(home, strings.TrimPrefix(s, "~"+string(os.PathSeparator))), nil
 		}
 	}
 

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -1,6 +1,7 @@
 package wishlist
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,10 @@ func TestUserKeys(t *testing.T) {
 		require.NoError(tb, os.MkdirAll(path, 0765))
 		_, err := keygen.NewWithWrite(path, "id", nil, keygen.RSA)
 		require.NoError(tb, err)
+		filepath.Walk(tmp, func(path string, info fs.FileInfo, err error) error {
+			t.Log(path)
+			return nil
+		})
 	}
 
 	t.Run("rsa", func(t *testing.T) {

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -1,0 +1,58 @@
+package wishlist
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserKeys(t *testing.T) {
+	fn := func(home string) func(string) (string, error) {
+		return func(s string) (string, error) {
+			return filepath.Join(home, strings.TrimPrefix(s, "~/")), nil
+		}
+	}
+
+	sshKeygen := func(tb testing.TB, cwd string, args ...string) {
+		tb.Helper()
+		cmd := exec.Command("ssh-keygen", args...)
+		cmd.Dir = filepath.Join(cwd, ".ssh")
+		require.NoError(tb, os.MkdirAll(cmd.Dir, 0766))
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+		t.Log(string(out))
+	}
+
+	t.Run("rsa", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		sshKeygen(t, tmp, "-t", "rsa", "-f", "./id_rsa", "-N", "", "-q")
+		methods, err := tryUserKeysInternal(fn(tmp))
+		require.NoError(t, err)
+		require.Len(t, methods, 1)
+	})
+
+	t.Run("ecdsa", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		sshKeygen(t, tmp, "-t", "ecdsa", "-f", "./id_rsa", "-N", "", "-q")
+		methods, err := tryUserKeysInternal(fn(tmp))
+		require.NoError(t, err)
+		require.Len(t, methods, 1)
+	})
+
+	t.Run("ed25519", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		sshKeygen(t, tmp, "-t", "ed25519", "-f", "./id_rsa", "-N", "", "-q")
+		methods, err := tryUserKeysInternal(fn(tmp))
+		require.NoError(t, err)
+		require.Len(t, methods, 1)
+	})
+
+	// TODO: how to test ecdsa-sk and ed25519-sk?
+}

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -1,7 +1,6 @@
 package wishlist
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +13,7 @@ import (
 func TestUserKeys(t *testing.T) {
 	fn := func(home string) func(string) (string, error) {
 		return func(s string) (string, error) {
+			t.Log("PATH IS", s)
 			return filepath.Join(home, strings.TrimPrefix(s, "~/")), nil
 		}
 	}
@@ -24,10 +24,6 @@ func TestUserKeys(t *testing.T) {
 		require.NoError(tb, os.MkdirAll(path, 0765))
 		_, err := keygen.NewWithWrite(path, "id", nil, keygen.RSA)
 		require.NoError(tb, err)
-		filepath.Walk(tmp, func(path string, info fs.FileInfo, err error) error {
-			t.Log(path)
-			return nil
-		})
 	}
 
 	t.Run("rsa", func(t *testing.T) {

--- a/client_local.go
+++ b/client_local.go
@@ -11,10 +11,7 @@ import (
 	"golang.org/x/term"
 )
 
-type SSHClient interface {
-	Connect(e *Endpoint) error
-}
-
+// NewLocalSSHClient returns a SSH Client for local usage.
 func NewLocalSSHClient() SSHClient {
 	return &localClient{}
 }
@@ -22,9 +19,6 @@ func NewLocalSSHClient() SSHClient {
 type localClient struct{}
 
 func (c *localClient) Connect(e *Endpoint) error {
-	// resetPty(os.Stdout)
-	// defer resetPty(os.Stdout)
-
 	user, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("failed to get current username: %w", err)
@@ -43,7 +37,7 @@ func (c *localClient) Connect(e *Endpoint) error {
 	session, cls, err := createSession(conf, e)
 	defer cls.close()
 	if err != nil {
-		return fmt.Errorf("failed to create sessio: %w", err)
+		return fmt.Errorf("failed to create session: %w", err)
 	}
 
 	session.Stdout = os.Stdout

--- a/client_local.go
+++ b/client_local.go
@@ -11,11 +11,19 @@ import (
 	"golang.org/x/term"
 )
 
+type SSHClient interface {
+	Connect(e *Endpoint) error
+}
+
+func NewLocalSSHClient() SSHClient {
+	return &localClient{}
+}
+
 type localClient struct{}
 
 func (c *localClient) Connect(e *Endpoint) error {
-	resetPty(os.Stdout)
-	defer resetPty(os.Stdout)
+	// resetPty(os.Stdout)
+	// defer resetPty(os.Stdout)
 
 	user, err := user.Current()
 	if err != nil {

--- a/client_local.go
+++ b/client_local.go
@@ -1,0 +1,64 @@
+package wishlist
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/term"
+)
+
+type localClient struct{}
+
+func (c *localClient) Connect(e *Endpoint) error {
+	resetPty(os.Stdout)
+	defer resetPty(os.Stdout)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home dir: %w", err)
+	}
+	user, err := user.Current()
+
+	if err != nil {
+		return fmt.Errorf("failed to get current username: %w", err)
+	}
+
+	methods, err := tryUserKeys(home)
+	if err != nil {
+		return fmt.Errorf("failed to get user keys: %w", err)
+	}
+	conf := &gossh.ClientConfig{
+		User:            firstNonEmpty(e.User, user.Username),
+		Auth:            methods,
+		HostKeyCallback: hostKeyCallback(e, filepath.Join(home, ".ssh/known_hosts")),
+	}
+
+	session, cls, err := createSession(conf, e)
+	defer cls.close()
+	if err != nil {
+		return fmt.Errorf("failed to create sessio: %w", err)
+	}
+
+	session.Stdout = os.Stdout
+	session.Stderr = os.Stderr
+	session.Stdin = os.Stdin
+
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return fmt.Errorf("failed to get term size: %w", err)
+	}
+
+	if err := session.RequestPty(os.Getenv("$TERM"), h, w, nil); err != nil {
+		return fmt.Errorf("failed to request a pty: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.notifyWindowChanges(ctx, session)
+
+	return shellAndWait(session)
+}

--- a/client_local.go
+++ b/client_local.go
@@ -22,14 +22,14 @@ func (c *localClient) Connect(e *Endpoint) error {
 		return fmt.Errorf("failed to get current username: %w", err)
 	}
 
-	method, err := localBestAuthMethod(e)
+	methods, err := localBestAuthMethod(e)
 	if err != nil {
 		return fmt.Errorf("failed to setup a authentication method: %w", err)
 	}
 	conf := &gossh.ClientConfig{
 		User:            firstNonEmpty(e.User, user.Username),
-		Auth:            []gossh.AuthMethod{method},
-		HostKeyCallback: hostKeyCallback(e, filepath.Join(home, ".ssh/known_hosts")),
+		Auth:            methods,
+		HostKeyCallback: hostKeyCallback(e, filepath.Join(user.HomeDir, ".ssh/known_hosts")),
 	}
 
 	session, cls, err := createSession(conf, e)
@@ -47,7 +47,7 @@ func (c *localClient) Connect(e *Endpoint) error {
 		return fmt.Errorf("failed to get term size: %w", err)
 	}
 
-	if err := session.RequestPty(os.Getenv("$TERM"), h, w, nil); err != nil {
+	if err := session.RequestPty(os.Getenv("TERM"), h, w, nil); err != nil {
 		return fmt.Errorf("failed to request a pty: %w", err)
 	}
 

--- a/client_local.go
+++ b/client_local.go
@@ -27,9 +27,18 @@ func (c *localClient) Connect(e *Endpoint) error {
 		return fmt.Errorf("failed to get current username: %w", err)
 	}
 
-	methods, err := tryUserKeys(home)
-	if err != nil {
-		return fmt.Errorf("failed to get user keys: %w", err)
+	var methods []gossh.AuthMethod
+	if e.IdentityFile == "" {
+		methods, err = tryUserKeys(home)
+		if err != nil {
+			return fmt.Errorf("failed to get user keys: %w", err)
+		}
+	} else {
+		method, err := tryIdentityFile(home, e.IdentityFile)
+		if err != nil {
+			return fmt.Errorf("failed to parse IdentityFile: %q: %w", e.IdentityFile, err)
+		}
+		methods = append(methods, method)
 	}
 	conf := &gossh.ClientConfig{
 		User:            firstNonEmpty(e.User, user.Username),

--- a/client_remote.go
+++ b/client_remote.go
@@ -30,7 +30,7 @@ func (c *remoteClient) Connect(e *Endpoint) error {
 		Auth:            []gossh.AuthMethod{method},
 	}
 
-	session, cl, err := createSession(conf, e)
+	session, _, cl, err := createSession(conf, e)
 	defer cl.close()
 	if err != nil {
 		return fmt.Errorf("failed to create session: %w", err)

--- a/client_remote.go
+++ b/client_remote.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/gliderlabs/ssh"
+	"github.com/muesli/termenv"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -71,4 +72,10 @@ func (c *remoteClient) notifyWindowChanges(session *gossh.Session, done <-chan b
 			}
 		}
 	}
+}
+
+func resetPty(w io.Writer) {
+	fmt.Fprint(w, termenv.CSI+termenv.ExitAltScreenSeq)
+	fmt.Fprint(w, termenv.CSI+termenv.ResetSeq+"m")
+	fmt.Fprintf(w, termenv.CSI+termenv.EraseDisplaySeq, 2) // nolint:gomnd
 }

--- a/client_remote.go
+++ b/client_remote.go
@@ -1,0 +1,74 @@
+package wishlist
+
+import (
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+type remoteClient struct {
+	session ssh.Session
+	stdin   io.Reader
+}
+
+func (c *remoteClient) Connect(e *Endpoint) error {
+	resetPty(c.session)
+
+	method, closers, err := remoteBestAuthMethod(c.session)
+	defer closers.close()
+	if err != nil {
+		return fmt.Errorf("failed to find an auth method: %w", err)
+	}
+
+	conf := &gossh.ClientConfig{
+		User:            firstNonEmpty(e.User, c.session.User()),
+		HostKeyCallback: hostKeyCallback(e, ".wishlist/known_hosts"),
+		Auth:            []gossh.AuthMethod{method},
+	}
+
+	session, cl, err := createSession(conf, e)
+	defer cl.close()
+	if err != nil {
+		return fmt.Errorf("failed to create session: %w", err)
+	}
+
+	log.Printf("%s connect to %q, %s", c.session.User(), e.Name, c.session.RemoteAddr().String())
+
+	session.Stdout = c.session
+	session.Stderr = c.session.Stderr()
+	session.Stdin = c.stdin
+
+	pty, winch, _ := c.session.Pty()
+	w := pty.Window
+	if err := session.RequestPty(pty.Term, w.Height, w.Width, nil); err != nil {
+		return fmt.Errorf("failed to request pty: %w", err)
+	}
+
+	done := make(chan bool, 1)
+	defer func() { done <- true }()
+
+	go c.notifyWindowChanges(session, done, winch)
+
+	return shellAndWait(session)
+}
+
+func (c *remoteClient) notifyWindowChanges(session *gossh.Session, done <-chan bool, winch <-chan ssh.Window) {
+	for {
+		select {
+		case <-done:
+			return
+		case w := <-winch:
+			if w.Height == 0 && w.Width == 0 {
+				// this only happens if the session is already dead, make sure there are no leftovers
+				return
+			}
+			if err := session.WindowChange(w.Height, w.Width); err != nil {
+				log.Println("failed to notify window change:", err)
+				return
+			}
+		}
+	}
+}

--- a/client_signals_unix.go
+++ b/client_signals_unix.go
@@ -1,0 +1,38 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package wishlist
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
+)
+
+func (c *localClient) notifyWindowChanges(ctx context.Context, session *ssh.Session) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGWINCH)
+	defer func() {
+		signal.Stop(sig)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-sig:
+			w, h, err := term.GetSize(int(os.Stdout.Fd()))
+			if err != nil {
+				log.Println(err)
+			}
+			if err := session.WindowChange(h, w); err != nil {
+				log.Println(err)
+			}
+		}
+	}
+}

--- a/client_signals_windows.go
+++ b/client_signals_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package wishlist
+
+import (
+	"context"
+	"golang.org/x/crypto/ssh"
+)
+
+// not available because windows does not implement siscall.SIGWINCH.
+func (c *localClient) notifyWindowChanges(ctx context.Context, session *ssh.Session) {}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,27 @@
+package wishlist
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClosers(t *testing.T) {
+	cl := closers{
+		func() error {
+			t.Log("close 1")
+			return nil
+		},
+		func() error {
+			t.Log("close 2")
+			return fmt.Errorf("fake error")
+		},
+	}
+	cl.close()
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	require.Equal(t, "a", firstNonEmpty("", "a"))
+	require.Equal(t, "", firstNonEmpty("", ""))
+}

--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -57,8 +57,12 @@ func main() {
 		if err != nil {
 			log.Fatalln(err)
 		}
-		defer f.Close()
-		p := tea.NewProgram(wishlist.NewListing(config.Endpoints, nil))
+		defer func() {
+			if err := f.Close(); err != nil {
+				log.Println(err)
+			}
+		}()
+		p := tea.NewProgram(wishlist.LocalListing(config.Endpoints))
 		if err := p.Start(); err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/wish/activeterm"
 	lm "github.com/charmbracelet/wish/logging"
 	"github.com/charmbracelet/wishlist"
+	"github.com/charmbracelet/wishlist/home"
 	"github.com/charmbracelet/wishlist/sshconfig"
 	"github.com/gliderlabs/ssh"
 	"github.com/hashicorp/go-multierror"
@@ -97,11 +98,8 @@ func getConfig(path string) (wishlist.Config, error) {
 		func() string { return ".wishlist/config.yml" },
 		func() string { return ".wishlist/config" },
 		func() string {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return ""
-			}
-			return filepath.Join(home, ".ssh/config")
+			s, _ := home.ExpandPath("~/.ssh/config")
+			return s
 		},
 		func() string { return "/etc/ssh/ssh_config" },
 	} {

--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -71,6 +71,7 @@ func main() {
 			return
 		}
 
+		log.SetOutput(os.Stderr)
 		if err := wishlist.NewLocalSSHClient().Connect(m.HandoffTo()); err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -62,10 +62,19 @@ func main() {
 				log.Println(err)
 			}
 		}()
-		p := tea.NewProgram(wishlist.LocalListing(config.Endpoints))
-		if err := p.Start(); err != nil {
+		m := wishlist.LocalListing(config.Endpoints)
+		if err := tea.NewProgram(m).Start(); err != nil {
 			log.Fatalln(err)
 		}
+
+		if m.HandoffTo() == nil {
+			return
+		}
+
+		if err := wishlist.NewLocalSSHClient().Connect(m.HandoffTo()); err != nil {
+			log.Fatalln(err)
+		}
+
 		return
 	}
 

--- a/config.go
+++ b/config.go
@@ -10,10 +10,11 @@ import (
 // Endpoint represents an endpoint to list.
 // If it has a Handler, wishlist will start an SSH server on the given address.
 type Endpoint struct {
-	Name        string            `yaml:"name"`    // Endpoint name.
-	Address     string            `yaml:"address"` // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
-	User        string            `yaml:"user"`    // User to authenticate as.
-	Middlewares []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
+	Name         string            `yaml:"name"`    // Endpoint name.
+	Address      string            `yaml:"address"` // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
+	User         string            `yaml:"user"`    // User to authenticate as.
+	IdentityFile string            `yaml:"-"`       // IdentityFile is only set when parsing from a SSH Config file, and used only on local mode.
+	Middlewares  []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
 }
 
 // String returns the endpoint in a friendly string format.

--- a/config.go
+++ b/config.go
@@ -10,12 +10,12 @@ import (
 // Endpoint represents an endpoint to list.
 // If it has a Handler, wishlist will start an SSH server on the given address.
 type Endpoint struct {
-	Name         string            `yaml:"name"`    // Endpoint name.
-	Address      string            `yaml:"address"` // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
-	User         string            `yaml:"user"`    // User to authenticate as.
-	IdentityFile string            `yaml:"-"`       // IdentityFile is only set when parsing from a SSH Config file, and used only on local mode.
-	ForwardAgent bool              `yaml:"-"`       // ForwardAgent is only set when parsing from a SSH Config file, and used only on local mode.
-	Middlewares  []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
+	Name          string            `yaml:"name"`    // Endpoint name.
+	Address       string            `yaml:"address"` // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
+	User          string            `yaml:"user"`    // User to authenticate as.
+	IdentityFiles []string          `yaml:"-"`       // IdentityFiles is only set when parsing from a SSH Config file, and used only on local mode.
+	ForwardAgent  bool              `yaml:"-"`       // ForwardAgent is only set when parsing from a SSH Config file, and used only on local mode.
+	Middlewares   []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
 }
 
 // String returns the endpoint in a friendly string format.

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
+
+replace github.com/charmbracelet/keygen => /home/carlos/Developer/charmbracelet/keygen

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/charmbracelet/bubbles v0.10.2
 	github.com/charmbracelet/bubbletea v0.19.3
-	github.com/charmbracelet/keygen v0.1.2
+	github.com/charmbracelet/keygen v0.2.0
 	github.com/charmbracelet/lipgloss v0.4.0
 	github.com/charmbracelet/wish v0.2.0
 	github.com/gliderlabs/ssh v0.3.3
@@ -18,5 +18,3 @@ require (
 	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
-
-replace github.com/charmbracelet/keygen => /home/carlos/Developer/charmbracelet/keygen

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/muesli/termenv v0.9.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce
+	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,9 @@ github.com/charmbracelet/bubbletea v0.19.0/go.mod h1:VuXF2pToRxDUHcBUcPmCRUHRvFA
 github.com/charmbracelet/bubbletea v0.19.3 h1:OKeO/Y13rQQqt4snX+lePB0QrnW80UdrMNolnCcmoAw=
 github.com/charmbracelet/bubbletea v0.19.3/go.mod h1:VuXF2pToRxDUHcBUcPmCRUHRvFATM4Ckb/ql1rBl3KA=
 github.com/charmbracelet/harmonica v0.1.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
-github.com/charmbracelet/keygen v0.1.2 h1:Gr/gdIOjDIxCTRVXpwa9tsXPoJPS2eGNehPoMnZLvTQ=
 github.com/charmbracelet/keygen v0.1.2/go.mod h1:kFQ3Cvop12fXWX1K29vxDxV9x8ujG4wBSXq//GySSSk=
+github.com/charmbracelet/keygen v0.2.0 h1:qIOzpnPRsbklVFw+syixgBl1E3q4u2fW9AmQ+ZVSwVw=
+github.com/charmbracelet/keygen v0.2.0/go.mod h1:kFQ3Cvop12fXWX1K29vxDxV9x8ujG4wBSXq//GySSSk=
 github.com/charmbracelet/lipgloss v0.4.0 h1:768h64EFkGUr8V5yAKV7/Ta0NiVceiPaV+PphaW1K9g=
 github.com/charmbracelet/lipgloss v0.4.0/go.mod h1:vmdkHvce7UzX6xkyf4cca8WlwdQ5RQr8fzta+xl7BOM=
 github.com/charmbracelet/wish v0.2.0 h1:KmOgvWVf82hPCnXDiAyaQi5WMwtA1b1zlNlVb3be4w0=

--- a/home/expand.go
+++ b/home/expand.go
@@ -1,0 +1,20 @@
+package home
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPath expands the given path if it starts with ~/.
+func ExpandPath(p string) (string, error) {
+	if !strings.HasPrefix(p, "~/") {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to expand path: %q: %w", p, err)
+	}
+	return filepath.Join(home, strings.TrimPrefix(p, "~/")), nil
+}

--- a/home/expand_test.go
+++ b/home/expand_test.go
@@ -1,0 +1,28 @@
+package home
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandPath(t *testing.T) {
+	t.Run("expand", func(t *testing.T) {
+		path, err := ExpandPath("~/.ssh/foo")
+		require.NoError(t, err)
+
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		require.Equal(t, filepath.Join(home, ".ssh/foo"), path)
+	})
+
+	t.Run("noexpand", func(t *testing.T) {
+		p := "/home/john/.ssh/foo"
+		path, err := ExpandPath(p)
+		require.NoError(t, err)
+		require.Equal(t, p, path)
+	})
+}

--- a/middleware.go
+++ b/middleware.go
@@ -103,3 +103,17 @@ func listenAppEvents(s ssh.Session, p *tea.Program, donech <-chan bool, errch <-
 		}
 	}
 }
+
+func mustConnect(s ssh.Session, e *Endpoint, stdin io.Reader) {
+	client := &remoteClient{
+		session: s,
+		stdin:   stdin,
+	}
+	if err := client.Connect(e); err != nil {
+		fmt.Fprintf(s, "wishlist: %s\n\r", err.Error())
+		_ = s.Exit(1)
+		return // unreachable
+	}
+	fmt.Fprintf(s, "wishlist: closed connection to %q (%s)\n\r", e.Name, e.Address)
+	_ = s.Exit(0)
+}

--- a/middleware.go
+++ b/middleware.go
@@ -56,7 +56,7 @@ func listingMiddleware(endpoints []*Endpoint) wish.Middleware {
 
 			errch := make(chan error, 1)
 			appch := make(chan bool, 1)
-			model := NewListing(endpoints, s)
+			model := newListing(endpoints, s)
 			p := tea.NewProgram(
 				model,
 				tea.WithInput(newBlockingReader(listStdin)),

--- a/middleware.go
+++ b/middleware.go
@@ -104,16 +104,13 @@ func listenAppEvents(s ssh.Session, p *tea.Program, donech <-chan bool, errch <-
 	}
 }
 
-func mustConnect(s ssh.Session, e *Endpoint, stdin io.Reader) {
-	client := &remoteClient{
-		session: s,
-		stdin:   stdin,
-	}
+func mustConnect(session ssh.Session, e *Endpoint, stdin io.Reader) {
+	client := &remoteClient{session, stdin}
 	if err := client.Connect(e); err != nil {
-		fmt.Fprintf(s, "wishlist: %s\n\r", err.Error())
-		_ = s.Exit(1)
+		fmt.Fprintf(session, "wishlist: %s\n\r", err.Error())
+		_ = session.Exit(1)
 		return // unreachable
 	}
-	fmt.Fprintf(s, "wishlist: closed connection to %q (%s)\n\r", e.Name, e.Address)
-	_ = s.Exit(0)
+	fmt.Fprintf(session, "wishlist: closed connection to %q (%s)\n\r", e.Name, e.Address)
+	_ = session.Exit(0)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -56,7 +56,7 @@ func listingMiddleware(endpoints []*Endpoint) wish.Middleware {
 
 			errch := make(chan error, 1)
 			appch := make(chan bool, 1)
-			model := newListing(endpoints, s)
+			model := NewListing(endpoints, s)
 			p := tea.NewProgram(
 				model,
 				tea.WithInput(newBlockingReader(listStdin)),

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/charmbracelet/wishlist"
+	"github.com/charmbracelet/wishlist/home"
 	"github.com/gobwas/glob"
 	"github.com/kevinburke/ssh_config"
 )
@@ -177,7 +177,7 @@ func parseInternal(r io.Reader) (*hostinfoMap, error) {
 				case "ForwardAgent":
 					info.ForwardAgent = value
 				case "Include":
-					path, err := ExpandPath(value)
+					path, err := home.ExpandPath(value)
 					if err != nil {
 						return nil, err
 					}
@@ -261,16 +261,4 @@ func parseFileInternal(path string) (*hostinfoMap, error) {
 	}
 	defer f.Close() // nolint:errcheck
 	return parseInternal(f)
-}
-
-// ExpandPath expands the given path if it starts with ~/.
-func ExpandPath(p string) (string, error) {
-	if !strings.HasPrefix(p, "~/") {
-		return p, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to expand path: %q: %w", p, err)
-	}
-	return filepath.Join(home, strings.TrimPrefix(p, "~/")), nil
 }

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -179,7 +179,7 @@ func parseInternal(r io.Reader) (*hostinfoMap, error) {
 				case "Include":
 					path, err := home.ExpandPath(value)
 					if err != nil {
-						return nil, err
+						return nil, err // nolint: wrapcheck
 					}
 					included, err := parseFileInternal(path)
 					if err != nil {

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -61,6 +61,8 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 					info.User = value
 				case "Port":
 					info.Port = value
+				case "IdentityFile":
+					info.IdentityFile = value
 				}
 			}
 
@@ -77,9 +79,10 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 			info.Port = "22"
 		}
 		endpoints = append(endpoints, &wishlist.Endpoint{
-			Name:    name,
-			Address: net.JoinHostPort(info.Hostname, info.Port),
-			User:    info.User,
+			Name:         name,
+			Address:      net.JoinHostPort(info.Hostname, info.Port),
+			User:         info.User,
+			IdentityFile: info.IdentityFile,
 		})
 	}
 
@@ -87,7 +90,8 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 }
 
 type hostinfo struct {
-	User     string
-	Hostname string
-	Port     string
+	User         string
+	Hostname     string
+	Port         string
+	IdentityFile string
 }

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -61,9 +61,9 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 				firstNonEmpty(info.Hostname, name),
 				firstNonEmpty(info.Port, "22"),
 			),
-			User:         info.User,
-			IdentityFile: info.IdentityFile,
-			ForwardAgent: stringToBool(info.ForwardAgent),
+			User:          info.User,
+			IdentityFiles: info.IdentityFiles,
+			ForwardAgent:  stringToBool(info.ForwardAgent),
 		})
 		return nil
 	}); err != nil {
@@ -88,11 +88,11 @@ func firstNonEmpty(ss ...string) string {
 }
 
 type hostinfo struct {
-	User         string
-	Hostname     string
-	Port         string
-	IdentityFile string
-	ForwardAgent string
+	User          string
+	Hostname      string
+	Port          string
+	IdentityFiles []string
+	ForwardAgent  string
 }
 
 type hostinfoMap struct {
@@ -173,7 +173,7 @@ func parseInternal(r io.Reader) (*hostinfoMap, error) {
 				case "Port":
 					info.Port = value
 				case "IdentityFile":
-					info.IdentityFile = value
+					info.IdentityFiles = append(info.IdentityFiles, value)
 				case "ForwardAgent":
 					info.ForwardAgent = value
 				case "Include":
@@ -245,9 +245,7 @@ func mergeHostinfo(h1, h2 hostinfo) hostinfo {
 	if h1.User != "" {
 		h2.User = h1.User
 	}
-	if h1.IdentityFile != "" {
-		h2.IdentityFile = h1.IdentityFile
-	}
+	h2.IdentityFiles = append(h2.IdentityFiles, h1.IdentityFiles...)
 	if h1.ForwardAgent != "" {
 		h2.ForwardAgent = h1.ForwardAgent
 	}

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -31,11 +31,11 @@ func TestParseFile(t *testing.T) {
 				Address: "app.foo.local:2222",
 			},
 			{
-				Name:         "app2",
-				Address:      "app.foo.local:2223",
-				User:         "someoneelse",
-				IdentityFile: "./testdata/key",
-				ForwardAgent: true,
+				Name:          "app2",
+				Address:       "app.foo.local:2223",
+				User:          "someoneelse",
+				IdentityFiles: []string{"./testdata/key"},
+				ForwardAgent:  true,
 			},
 			{
 				Name:    "multiple1",
@@ -90,10 +90,10 @@ func TestParseIncludes(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*wishlist.Endpoint{
 		{
-			Name:         "test.foo.bar",
-			Address:      "test.foo.bar:2222",
-			User:         "ciclano",
-			IdentityFile: "~/.ssh/id_rsa2",
+			Name:          "test.foo.bar",
+			Address:       "test.foo.bar:2222",
+			User:          "ciclano",
+			IdentityFiles: []string{"~/.ssh/id_rsa2", "~/.ssh/other_id"},
 		},
 		{
 			Name:    "something.else",
@@ -108,25 +108,26 @@ func TestMergeMaps(t *testing.T) {
 		t,
 		map[string]hostinfo{
 			"foo": {
-				Hostname:     "foo.bar",
-				User:         "me",
-				IdentityFile: "id_rsa",
-				Port:         "2321",
+				Hostname:      "foo.bar",
+				User:          "me",
+				IdentityFiles: []string{"id_rsa", "id_ed25519"},
+				Port:          "2321",
 			},
 			"bar": {
 				User: "yoda",
 			},
 			"foobar": {
-				User:         "notme",
-				Hostname:     "foobar.foo",
-				IdentityFile: "id_ed25519",
+				User:          "notme",
+				Hostname:      "foobar.foo",
+				IdentityFiles: []string{"id_ed25519"},
 			},
 		},
 		merge(
 			newHostinfoMapFrom(
 				map[string]hostinfo{
 					"foo": {
-						Hostname: "foo.bar",
+						Hostname:      "foo.bar",
+						IdentityFiles: []string{"id_ed25519"},
 					},
 					"bar": {
 						User: "yoda",
@@ -136,14 +137,14 @@ func TestMergeMaps(t *testing.T) {
 			newHostinfoMapFrom(
 				map[string]hostinfo{
 					"foo": {
-						User:         "me",
-						IdentityFile: "id_rsa",
-						Port:         "2321",
+						User:          "me",
+						IdentityFiles: []string{"id_rsa"},
+						Port:          "2321",
 					},
 					"foobar": {
-						User:         "notme",
-						Hostname:     "foobar.foo",
-						IdentityFile: "id_ed25519",
+						User:          "notme",
+						Hostname:      "foobar.foo",
+						IdentityFiles: []string{"id_ed25519"},
 					},
 				},
 			),

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -30,9 +30,10 @@ func TestParseFile(t *testing.T) {
 				Address: "app.foo.local:2222",
 			},
 			{
-				Name:    "app2",
-				Address: "app.foo.local:2223",
-				User:    "someoneelse",
+				Name:         "app2",
+				Address:      "app.foo.local:2223",
+				User:         "someoneelse",
+				IdentityFile: "./testdata/key",
 			},
 			{
 				Name:    "multiple1",

--- a/sshconfig/testdata/good.ssh_config
+++ b/sshconfig/testdata/good.ssh_config
@@ -17,7 +17,7 @@ Host app2
   HostName app.foo.local
   User someoneelse
   Port 2223
-  IdentityFile ignored
+  IdentityFile ./testdata/key
 
 Host multiple1 multiple2 multiple3
   User multi

--- a/sshconfig/testdata/include.ssh_config
+++ b/sshconfig/testdata/include.ssh_config
@@ -2,6 +2,7 @@ Include ./testdata/included.ssh_config
 
 Host test.foo.bar
 	Port 2222
+	IdentityFile ~/.ssh/other_id
 
 Host something.else
 	Port 2323

--- a/wishlist.go
+++ b/wishlist.go
@@ -2,6 +2,7 @@ package wishlist
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
@@ -17,7 +18,7 @@ var enter = key.NewBinding(
 	key.WithHelp("Enter", "Connect"),
 )
 
-func newListing(endpoints []*Endpoint, s ssh.Session) *listModel {
+func NewListing(endpoints []*Endpoint, s ssh.Session) *listModel {
 	var items []list.Item
 	for _, endpoint := range endpoints {
 		if endpoint.Valid() {
@@ -65,6 +66,16 @@ func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.handoff = selectedItem.(*Endpoint)
+			if m.session == nil {
+				// local run
+				return m, func() tea.Msg {
+					log.Println("local connect")
+					if err := connectLocal(m.handoff); err != nil {
+						log.Println(err)
+					}
+					return nil
+				}
+			}
 			return m, tea.Quit
 		}
 	case tea.WindowSizeMsg:

--- a/wishlist.go
+++ b/wishlist.go
@@ -73,7 +73,7 @@ func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if err := connectLocal(m.handoff); err != nil {
 						log.Println(err)
 					}
-					return nil
+					return tea.Quit()
 				}
 			}
 			return m, tea.Quit

--- a/wishlist.go
+++ b/wishlist.go
@@ -17,6 +17,7 @@ var enter = key.NewBinding(
 	key.WithHelp("Enter", "Connect"),
 )
 
+// HandoffModel is a tea.Model that can tell where it should ssh into.
 type HandoffModel interface {
 	tea.Model
 	HandoffTo() *Endpoint

--- a/wishlist.go
+++ b/wishlist.go
@@ -69,11 +69,11 @@ func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.session == nil {
 				// local run
 				return m, func() tea.Msg {
-					log.Println("local connect")
-					if err := connectLocal(m.handoff); err != nil {
+					client := &localClient{}
+					if err := client.Connect(m.handoff); err != nil {
 						log.Println(err)
 					}
-					return tea.Quit()
+					return tea.Quit
 				}
 			}
 			return m, tea.Quit

--- a/wishlist.go
+++ b/wishlist.go
@@ -18,7 +18,12 @@ var enter = key.NewBinding(
 	key.WithHelp("Enter", "Connect"),
 )
 
-func NewListing(endpoints []*Endpoint, s ssh.Session) *listModel {
+// LocalListing creates a new listing model for local usage only.
+func LocalListing(endpoints []*Endpoint) tea.Model {
+	return newListing(endpoints, nil)
+}
+
+func newListing(endpoints []*Endpoint, s ssh.Session) *listModel {
 	var items []list.Item
 	for _, endpoint := range endpoints {
 		if endpoint.Valid() {

--- a/wishlist.go
+++ b/wishlist.go
@@ -58,6 +58,9 @@ func (m *listModel) Init() tea.Cmd {
 }
 
 func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.handoff != nil {
+		return m, nil
+	}
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		if key.Matches(msg, enter) {
@@ -68,13 +71,13 @@ func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.handoff = selectedItem.(*Endpoint)
 			if m.session == nil {
 				// local run
-				return m, func() tea.Msg {
+				return m, tea.Sequentially(func() tea.Msg {
 					client := &localClient{}
 					if err := client.Connect(m.handoff); err != nil {
 						log.Println(err)
 					}
-					return tea.Quit
-				}
+					return nil
+				}, tea.Quit)
 			}
 			return m, tea.Quit
 		}
@@ -89,5 +92,8 @@ func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *listModel) View() string {
+	if m.handoff != nil {
+		return ""
+	}
 	return docStyle.Render(m.list.View())
 }


### PR DESCRIPTION
Allow wishlist to run locally, meaning it'll be just an interface for the config file.

When you run with `--local`, you'll go directly to the TUI, and can then browse/SSH into your SSH targets from `~/.ssh/config`

#### TODO

- [x] parse `IdentityFile` from SSH config
- [x] parse and evaluate `Includes` on SSH configs (?) (#21)
- [x] readme
- [x] forward host (do in another PR) (#22)