### PR TITLE
feat: parse Include, IdentityFile and wildcards

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,10 +10,11 @@ import (
 // Endpoint represents an endpoint to list.
 // If it has a Handler, wishlist will start an SSH server on the given address.
 type Endpoint struct {
-	Name        string            `yaml:"name"`    // Endpoint name.
-	Address     string            `yaml:"address"` // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
-	User        string            `yaml:"user"`    // User to authenticate as.
-	Middlewares []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
+	Name         string            `yaml:"name"`    // Endpoint name.
+	Address      string            `yaml:"address"` // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
+	User         string            `yaml:"user"`    // User to authenticate as.
+	IdentityFile string            `yaml:"-"`       // IdentityFile is only set when parsing from a SSH Config file, and used only on local mode.
+	Middlewares  []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
 }
 
 // String returns the endpoint in a friendly string format.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.4.0
 	github.com/charmbracelet/wish v0.1.2
 	github.com/gliderlabs/ssh v0.3.3
+	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kevinburke/ssh_config v1.1.0
 	github.com/muesli/termenv v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -44,7 +44,7 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 			}
 			g, err := glob.Compile(k)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid Host: %q: %w", k, err)
 			}
 			if g.Match(name) {
 				info = mergeHostinfo(info, v)

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -33,7 +33,7 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 
 	wildcards, hosts := split(infos)
 
-	endpoints := make([]*wishlist.Endpoint, 0, infos.lenght())
+	endpoints := make([]*wishlist.Endpoint, 0, infos.length())
 	if err := hosts.forEach(func(name string, info hostinfo, err error) error {
 		if err != nil {
 			return err
@@ -93,7 +93,7 @@ type hostinfoMap struct {
 	lock sync.Mutex
 }
 
-func (m *hostinfoMap) lenght() int {
+func (m *hostinfoMap) length() int {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	return len(m.keys)

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -4,11 +4,13 @@ package sshconfig
 import (
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 	"strings"
 
 	"github.com/charmbracelet/wishlist"
+	"github.com/gobwas/glob"
 	"github.com/kevinburke/ssh_config"
 )
 
@@ -24,6 +26,51 @@ func ParseFile(path string) ([]*wishlist.Endpoint, error) {
 
 // ParseReader reads and parses the given reader.
 func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
+	infos, err := parseInternal(r)
+	if err != nil {
+		return nil, err
+	}
+
+	wildcards, hosts := split(infos)
+
+	endpoints := make([]*wishlist.Endpoint, 0, len(infos))
+	for name, info := range hosts {
+		for k, v := range wildcards {
+			g, err := glob.Compile(k)
+			if err != nil {
+				return nil, err
+			}
+			if g.Match(name) {
+				info = mergeHostinfo(info, v)
+			}
+		}
+
+		if info.Hostname == "" {
+			info.Hostname = name // Host foo.bar, use foo.bar as name and HostName
+		}
+		if info.Port == "" {
+			info.Port = "22"
+		}
+
+		endpoints = append(endpoints, &wishlist.Endpoint{
+			Name:         name,
+			Address:      net.JoinHostPort(info.Hostname, info.Port),
+			User:         info.User,
+			IdentityFile: info.IdentityFile,
+		})
+	}
+
+	return endpoints, nil
+}
+
+type hostinfo struct {
+	User         string
+	Hostname     string
+	Port         string
+	IdentityFile string
+}
+
+func parseInternal(r io.Reader) (map[string]hostinfo, error) {
 	config, err := ssh_config.Decode(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config: %w", err)
@@ -34,11 +81,6 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 	for _, h := range config.Hosts {
 		for _, pattern := range h.Patterns {
 			name := pattern.String()
-
-			if strings.Contains(name, "*") {
-				continue // ignore wildcards
-			}
-
 			info := infos[name]
 			for _, n := range h.Nodes {
 				node := strings.TrimSpace(n.String())
@@ -61,6 +103,17 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 					info.User = value
 				case "Port":
 					info.Port = value
+				case "IdentityFile":
+					info.IdentityFile = value
+				case "Include":
+					included, err := parseFileInternal(value)
+					if err != nil {
+						return nil, err
+					}
+					log.Println("INCLUDED", included)
+					infos[name] = info
+					infos = merge(infos, included)
+					info = infos[name]
 				}
 			}
 
@@ -68,26 +121,63 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 		}
 	}
 
-	endpoints := make([]*wishlist.Endpoint, 0, len(infos))
-	for name, info := range infos {
-		if info.Hostname == "" {
-			info.Hostname = name // Host foo.bar, use foo.bar as name and HostName
-		}
-		if info.Port == "" {
-			info.Port = "22"
-		}
-		endpoints = append(endpoints, &wishlist.Endpoint{
-			Name:    name,
-			Address: net.JoinHostPort(info.Hostname, info.Port),
-			User:    info.User,
-		})
-	}
-
-	return endpoints, nil
+	return infos, nil
 }
 
-type hostinfo struct {
-	User     string
-	Hostname string
-	Port     string
+func split(m map[string]hostinfo) (wildcards map[string]hostinfo, hosts map[string]hostinfo) {
+	wildcards = map[string]hostinfo{}
+	hosts = map[string]hostinfo{}
+	for k, v := range m {
+		if strings.Contains(k, "*") {
+			wildcards[k] = v
+			continue
+		}
+		hosts[k] = v
+	}
+	return
+}
+
+func merge(m1, m2 map[string]hostinfo) map[string]hostinfo {
+	result := map[string]hostinfo{}
+
+	for k, v := range m1 {
+		vv, ok := m2[k]
+		if !ok {
+			result[k] = v
+			continue
+		}
+		result[k] = mergeHostinfo(v, vv)
+	}
+
+	for k, v := range m2 {
+		if _, ok := m1[k]; !ok {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func mergeHostinfo(h1, h2 hostinfo) hostinfo {
+	if h1.Port != "" {
+		h2.Port = h1.Port
+	}
+	if h1.Hostname != "" {
+		h2.Hostname = h1.Hostname
+	}
+	if h1.User != "" {
+		h2.User = h1.User
+	}
+	if h1.IdentityFile != "" {
+		h2.IdentityFile = h1.IdentityFile
+	}
+	return h2
+}
+
+func parseFileInternal(path string) (map[string]hostinfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config: %w", err)
+	}
+	defer f.Close() // nolint:errcheck
+	return parseInternal(f)
 }

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -88,9 +88,9 @@ type hostinfo struct {
 }
 
 type hostinfoMap struct {
-	m    map[string]hostinfo
-	keys []string
-	lock sync.Mutex
+	inner map[string]hostinfo
+	keys  []string
+	lock  sync.Mutex
 }
 
 func (m *hostinfoMap) length() int {
@@ -102,16 +102,16 @@ func (m *hostinfoMap) length() int {
 func (m *hostinfoMap) set(k string, v hostinfo) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if _, ok := m.m[k]; !ok {
+	if _, ok := m.inner[k]; !ok {
 		m.keys = append(m.keys, k)
 	}
-	m.m[k] = v
+	m.inner[k] = v
 }
 
 func (m *hostinfoMap) get(k string) (hostinfo, bool) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	v, ok := m.m[k]
+	v, ok := m.inner[k]
 	return v, ok
 }
 
@@ -120,14 +120,14 @@ func (m *hostinfoMap) forEach(fn func(string, hostinfo, error) error) error {
 	defer m.lock.Unlock()
 	var err error
 	for _, k := range m.keys {
-		err = fn(k, m.m[k], err)
+		err = fn(k, m.inner[k], err)
 	}
 	return err
 }
 
 func newHostinfoMap() *hostinfoMap {
 	return &hostinfoMap{
-		m: map[string]hostinfo{},
+		inner: map[string]hostinfo{},
 	}
 }
 

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -4,7 +4,6 @@ package sshconfig
 import (
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strings"
@@ -110,7 +109,6 @@ func parseInternal(r io.Reader) (map[string]hostinfo, error) {
 					if err != nil {
 						return nil, err
 					}
-					log.Println("INCLUDED", included)
 					infos[name] = info
 					infos = merge(infos, included)
 					info = infos[name]

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -121,7 +121,7 @@ func TestMergeMaps(t *testing.T) {
 			},
 		},
 		merge(
-			newOrderedMapFrom(
+			newHostinfoMapFrom(
 				map[string]hostinfo{
 					"foo": {
 						Hostname: "foo.bar",
@@ -131,7 +131,7 @@ func TestMergeMaps(t *testing.T) {
 					},
 				},
 			),
-			newOrderedMapFrom(
+			newHostinfoMapFrom(
 				map[string]hostinfo{
 					"foo": {
 						User:         "me",
@@ -150,7 +150,7 @@ func TestMergeMaps(t *testing.T) {
 }
 
 func TestSplit(t *testing.T) {
-	wildcards, hosts := split(newOrderedMapFrom(map[string]hostinfo{
+	wildcards, hosts := split(newHostinfoMapFrom(map[string]hostinfo{
 		"*.foo.bar": {User: "yoda"},
 		"*":         {Hostname: "foobar"},
 		"foo.bar":   {User: "john"},
@@ -169,8 +169,8 @@ func TestSplit(t *testing.T) {
 	}, hosts.m)
 }
 
-func TestOrderedMap(t *testing.T) {
-	m := newOrderedMap()
+func TestHostinfoMap(t *testing.T) {
+	m := newHostinfoMap()
 	m.set("a", hostinfo{
 		User: "a",
 	})
@@ -212,8 +212,8 @@ func TestOrderedMap(t *testing.T) {
 	}))
 }
 
-func newOrderedMapFrom(input map[string]hostinfo) *orderedMap {
-	m := newOrderedMap()
+func newHostinfoMapFrom(input map[string]hostinfo) *hostinfoMap {
+	m := newHostinfoMap()
 	for k, v := range input {
 		m.set(k, v)
 	}

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -157,13 +157,13 @@ func TestSplit(t *testing.T) {
 	},
 	))
 
-	require.Equal(t, 2, wildcards.lenght())
+	require.Equal(t, 2, wildcards.length())
 	require.Equal(t, map[string]hostinfo{
 		"*.foo.bar": {User: "yoda"},
 		"*":         {Hostname: "foobar"},
 	}, wildcards.m)
 
-	require.Equal(t, 1, hosts.lenght())
+	require.Equal(t, 1, hosts.length())
 	require.Equal(t, map[string]hostinfo{
 		"foo.bar": {User: "john"},
 	}, hosts.m)
@@ -189,10 +189,10 @@ func TestHostinfoMap(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, hostinfo{User: "b"}, b)
 
-	require.Equal(t, len(m.m), m.lenght())
-	require.Equal(t, len(m.keys), m.lenght())
+	require.Equal(t, len(m.m), m.length())
+	require.Equal(t, len(m.keys), m.length())
 
-	order := make([]string, 0, m.lenght())
+	order := make([]string, 0, m.length())
 	require.NoError(t, m.forEach(func(s string, _ hostinfo, _ error) error {
 		order = append(order, s)
 		return nil

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -15,7 +15,6 @@ func TestParseFile(t *testing.T) {
 		endpoints, err := ParseFile("testdata/good.ssh_config")
 		require.NoError(t, err)
 
-		t.Log(endpoints)
 		require.ElementsMatch(t, []*wishlist.Endpoint{
 			{
 				Name:    "darkstar",
@@ -159,4 +158,3 @@ func TestSplit(t *testing.T) {
 		"*":         {Hostname: "foobar"},
 	}, wildcards)
 }
-

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -145,7 +145,7 @@ func TestMergeMaps(t *testing.T) {
 					},
 				},
 			),
-		).m,
+		).inner,
 	)
 }
 
@@ -161,12 +161,12 @@ func TestSplit(t *testing.T) {
 	require.Equal(t, map[string]hostinfo{
 		"*.foo.bar": {User: "yoda"},
 		"*":         {Hostname: "foobar"},
-	}, wildcards.m)
+	}, wildcards.inner)
 
 	require.Equal(t, 1, hosts.length())
 	require.Equal(t, map[string]hostinfo{
 		"foo.bar": {User: "john"},
-	}, hosts.m)
+	}, hosts.inner)
 }
 
 func TestHostinfoMap(t *testing.T) {
@@ -189,7 +189,7 @@ func TestHostinfoMap(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, hostinfo{User: "b"}, b)
 
-	require.Equal(t, len(m.m), m.length())
+	require.Equal(t, len(m.inner), m.length())
 	require.Equal(t, len(m.keys), m.length())
 
 	order := make([]string, 0, m.length())

--- a/sshconfig/testdata/good.ssh_config
+++ b/sshconfig/testdata/good.ssh_config
@@ -6,9 +6,6 @@ Host supernova
   User notme
   ForwardAgent does-not-matter
 
-Host *
-  Hostname ignored-because-wildcard
-
 Host app1
   HostName app.foo.local
   Port 2222
@@ -17,7 +14,8 @@ Host app2
   HostName app.foo.local
   User someoneelse
   Port 2223
-  IdentityFile ignored
+  IdentityFile ./testdata/key
+
 
 Host multiple1 multiple2 multiple3
   User multi

--- a/sshconfig/testdata/include.ssh_config
+++ b/sshconfig/testdata/include.ssh_config
@@ -1,0 +1,7 @@
+Include ./testdata/included.ssh_config
+
+Host test.foo.bar
+	Port 2222
+
+Host something.else
+	Port 2323

--- a/sshconfig/testdata/included.ssh_config
+++ b/sshconfig/testdata/included.ssh_config
@@ -1,0 +1,6 @@
+Host *
+	User ciclano
+
+Host *.foo.bar
+	User fulano
+	IdentityFile ~/.ssh/id_rsa2


### PR DESCRIPTION
this allows to parse `Include` statements on ssh config files, as well as deal with globs.

Testing how SSH parses, it seems like its in order... so this should do more or less the same thing.