### PR TITLE
feat: handle request tty and remote command

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,7 +1,9 @@
 package wishlist
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"log"
 
 	gossh "golang.org/x/crypto/ssh"
@@ -45,6 +47,10 @@ type closers []func() error
 func (c closers) close() {
 	for _, closer := range c {
 		if err := closer(); err != nil {
+			if errors.Is(err, io.EOF) {
+				// do not print EOF errors... not a big deal anyway
+				continue
+			}
 			log.Println("failed to close:", err)
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -15,6 +15,8 @@ type Endpoint struct {
 	User          string            `yaml:"user"`    // User to authenticate as.
 	IdentityFiles []string          `yaml:"-"`       // IdentityFiles is only set when parsing from a SSH Config file, and used only on local mode.
 	ForwardAgent  bool              `yaml:"-"`       // ForwardAgent is only set when parsing from a SSH Config file, and used only on local mode.
+	RequestTTY    bool              `yaml:"-"`       // RequestTTY is only set when parsing from a SSH Config file, and used only on local mode. It defaults to true if RemoteCommand is empty.
+	RemoteCommand string            `yaml:"-"`       // RemoteCommand is only set when parsing from a SSH Config fil, and use only on local mode. By default wishlist will request a shell.
 	Middlewares   []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
 }
 

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -64,6 +64,8 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 			User:          info.User,
 			IdentityFiles: info.IdentityFiles,
 			ForwardAgent:  stringToBool(info.ForwardAgent),
+			RequestTTY:    stringToBool(info.RequestTTY),
+			RemoteCommand: info.RemoteCommand,
 		})
 		return nil
 	}); err != nil {
@@ -93,6 +95,8 @@ type hostinfo struct {
 	Port          string
 	IdentityFiles []string
 	ForwardAgent  string
+	RequestTTY    string
+	RemoteCommand string
 }
 
 type hostinfoMap struct {
@@ -176,6 +180,10 @@ func parseInternal(r io.Reader) (*hostinfoMap, error) {
 					info.IdentityFiles = append(info.IdentityFiles, value)
 				case "ForwardAgent":
 					info.ForwardAgent = value
+				case "RequestTTY":
+					info.RequestTTY = value
+				case "RemoteCommand":
+					info.RemoteCommand = value
 				case "Include":
 					path, err := home.ExpandPath(value)
 					if err != nil {
@@ -248,6 +256,12 @@ func mergeHostinfo(h1, h2 hostinfo) hostinfo {
 	h2.IdentityFiles = append(h2.IdentityFiles, h1.IdentityFiles...)
 	if h1.ForwardAgent != "" {
 		h2.ForwardAgent = h1.ForwardAgent
+	}
+	if h1.RequestTTY != "" {
+		h2.RequestTTY = h1.RequestTTY
+	}
+	if h1.RemoteCommand != "" {
+		h2.RemoteCommand = h1.RemoteCommand
 	}
 	return h2
 }

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -112,6 +112,8 @@ func TestMergeMaps(t *testing.T) {
 				User:          "me",
 				IdentityFiles: []string{"id_rsa", "id_ed25519"},
 				Port:          "2321",
+				RequestTTY:    "yes",
+				RemoteCommand: "tmux new -A -s default",
 			},
 			"bar": {
 				User: "yoda",
@@ -128,6 +130,7 @@ func TestMergeMaps(t *testing.T) {
 					"foo": {
 						Hostname:      "foo.bar",
 						IdentityFiles: []string{"id_ed25519"},
+						RequestTTY:    "yes",
 					},
 					"bar": {
 						User: "yoda",
@@ -140,6 +143,7 @@ func TestMergeMaps(t *testing.T) {
 						User:          "me",
 						IdentityFiles: []string{"id_rsa"},
 						Port:          "2321",
+						RemoteCommand: "tmux new -A -s default",
 					},
 					"foobar": {
 						User:          "notme",


### PR DESCRIPTION
this handles `RequestTTY` and `RemoteCommand` in local mode.

This should mimic SSH behavior:

- if no `RemoteCommand`, start a shell - which should request a TTY
- if `RequestTTY` explicitly set to false, do not request a TTY - will fail if `RemoteCommand` requires one - or is not set, which requests a shell, which requires a TTY
- If `RemoteCommand` is set, respect `RequestTTY`, which defaults to false