### PR TITLE
feat: uses RemoteCommand and ForwardAgent when using remote mode as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Check the [example config file](/_example/config.yaml) file as well as `wishlist
 
 #### Local
 
-If you want to explore your own local servers, you can simply run `wishlist --local` to be presented with a the UI filled with your `~/.ssh/config` hosts.
+If you want to explore your own local servers, you can simply run `wishlist --local` to be presented with an UI filled with your `~/.ssh/config` hosts.
 
 ### Library
 

--- a/_example/config.ssh_config
+++ b/_example/config.ssh_config
@@ -2,17 +2,33 @@
 # setup wishlist with a SSH config file
 #
 
+# Includes another config file.
+Include ~/.ssh/config.other
+
+# Hosts will wildcards will not show up in the list
+Host *.bar
+	# Forwards the agent to the target host.
+	ForwardAgent true
+
+	# Requests a TTY. This is on by default if RemoteCommand is empty.
+	RequestTTY yes
+
+	# Command to run on the connection. By default, it'll require a shell.
+	RemoteCommand tmux a
+
 # Host will be endpoint's name
 Host foo
 	# HostName will be used as the host part of the address
-	HostName bar
+	HostName foo.bar
+
 	# Port will be used as the port part of the address
 	Port 2223
+
 	# User that should be used to connect to the remote host
 	User notme
 
-	# all other SSH options are ignored
-	# wildcard Hosts are also ignored
+	# Private key to use.
+	IdentityFile ~/.ssh/foo_ed25519
 
 # Having only the Host key also works, it'll be both the endpoint's name and
 #  hostname, using 22 as default port

--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -2,17 +2,50 @@
 # setup wishlist with a YAML file
 #
 
-listen: 127.0.0.1         # defaults to 0.0.0.0
-port: 2223                # defaults to 22 or 2222, whichever is open
 
-endpoints:                # endpoints to list
-- name: appname           # prefer to avoid spaces
-  address: foo.local:2234 # address in host:port format
-  user: notme             # overrides user, defauts to client's user
+# Address in which wishlist should listen for.
+# Defaults to 0.0.0.0.
+listen: 127.0.0.1
 
-users:                    # users to allow access to the list
-- name: carlos            # user login
-  public-keys:            # their public keys in plain text
-  - ssh-rsa AAAAB3Nz...   # string redacted for the sake of brevity
-  - ssh-ed25519 AAAA...   #
+# Port in which wishlist should listen for.
+# Defaults to 22 or 2222, whichever is open.
+port: 2223
+
+# Endpoints to list in the UI.
+endpoints:
+-
+  # Endpoint's name.
+  # Recommended to avoid spaces so users can `ssh -t appname`.
+  name: appname
+
+  # Endpoint's address in the host:port format.
+  address: foo.local:2234
+
+  # User to use to connect.
+  # Defaults to the current remote user.
+  user: notme
+
+  # Command to run against the remote address.
+  # Defaults to asking for a shell.
+  remote_command: uptime -a
+
+  # Wether to forward the SSH agent.
+  # Will cause the connection to fail if no agent is available.
+  forward_agent: true # forwards the ssh agent
+
+  # requests a TTY.
+  # Defaults to true if remote_command is empty.
+  request_tty: true
+
+# users to allow access to the list
+users:
+  -
+    # user login
+    name: carlos
+
+    # User's public keys.
+    # Must be in the same format as seen in the ~/.allowed_keys file.
+    public-keys:
+    - ssh-rsa AAAAB3Nz...
+    - ssh-ed25519 AAAA...
 

--- a/client.go
+++ b/client.go
@@ -32,10 +32,24 @@ func createSession(conf *gossh.ClientConfig, e *Endpoint) (*gossh.Session, *goss
 }
 
 func shellAndWait(session *gossh.Session) error {
+	log.Println("requesting shell")
 	if err := session.Shell(); err != nil {
 		return fmt.Errorf("failed to start shell: %w", err)
 	}
+	return sessionWait(session)
+}
 
+func runAndWait(session *gossh.Session, cmd string) error {
+	log.Printf("running %q", cmd)
+	if err := session.Run(cmd); err != nil {
+		return fmt.Errorf("failed to run %q: %w", cmd, err)
+	}
+
+	log.Println("waiting")
+	return sessionWait(session)
+}
+
+func sessionWait(session *gossh.Session) error {
 	if err := session.Wait(); err != nil {
 		return fmt.Errorf("session failed: %w", err)
 	}

--- a/client.go
+++ b/client.go
@@ -41,7 +41,7 @@ func shellAndWait(session *gossh.Session) error {
 
 func runAndWait(session *gossh.Session, cmd string) error {
 	log.Printf("running %q", cmd)
-	if err := session.Run(cmd); err != nil {
+	if err := session.Start(cmd); err != nil {
 		return fmt.Errorf("failed to run %q: %w", cmd, err)
 	}
 

--- a/client.go
+++ b/client.go
@@ -36,22 +36,16 @@ func shellAndWait(session *gossh.Session) error {
 	if err := session.Shell(); err != nil {
 		return fmt.Errorf("failed to start shell: %w", err)
 	}
-	return sessionWait(session)
+	if err := session.Wait(); err != nil {
+		return fmt.Errorf("session failed: %w", err)
+	}
+	return nil
 }
 
 func runAndWait(session *gossh.Session, cmd string) error {
 	log.Printf("running %q", cmd)
-	if err := session.Start(cmd); err != nil {
+	if err := session.Run(cmd); err != nil {
 		return fmt.Errorf("failed to run %q: %w", cmd, err)
-	}
-
-	log.Println("waiting")
-	return sessionWait(session)
-}
-
-func sessionWait(session *gossh.Session) error {
-	if err := session.Wait(); err != nil {
-		return fmt.Errorf("session failed: %w", err)
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -10,14 +10,14 @@ import (
 // Endpoint represents an endpoint to list.
 // If it has a Handler, wishlist will start an SSH server on the given address.
 type Endpoint struct {
-	Name          string            `yaml:"name"`    // Endpoint name.
-	Address       string            `yaml:"address"` // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
-	User          string            `yaml:"user"`    // User to authenticate as.
-	IdentityFiles []string          `yaml:"-"`       // IdentityFiles is only set when parsing from a SSH Config file, and used only on local mode.
-	ForwardAgent  bool              `yaml:"-"`       // ForwardAgent is only set when parsing from a SSH Config file, and used only on local mode.
-	RequestTTY    bool              `yaml:"-"`       // RequestTTY is only set when parsing from a SSH Config file, and used only on local mode. It defaults to true if RemoteCommand is empty.
-	RemoteCommand string            `yaml:"-"`       // RemoteCommand is only set when parsing from a SSH Config fil, and use only on local mode. By default wishlist will request a shell.
-	Middlewares   []wish.Middleware `yaml:"-"`       // wish middlewares you can use in the factory method.
+	Name          string            `yaml:"name"`           // Endpoint name.
+	Address       string            `yaml:"address"`        // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
+	User          string            `yaml:"user"`           // User to authenticate as.
+	ForwardAgent  bool              `yaml:"forward_agent"`  // ForwardAgent defines wether to forward the current agent. Anologous to SSH's config ForwardAgent.
+	RequestTTY    bool              `yaml:"request_tty"`    // RequestTTY defines wether to request a TTY. Anologous to SSH's config RequestTTY.
+	RemoteCommand string            `yaml:"remote_command"` // RemoteCommand defines wether to request a TTY. Anologous to SSH's config RemoteCommand.
+	IdentityFiles []string          `yaml:"-"`              // IdentityFiles is only set when parsing from a SSH Config file, and used only on local mode.
+	Middlewares   []wish.Middleware `yaml:"-"`              // wish middlewares you can use in the factory method.
 }
 
 // String returns the endpoint in a friendly string format.


### PR DESCRIPTION
- use `RemoteCommand` on remote mode
- use `ForwardAgent` on remote mode (which will forward further the previously forwarded agent, if any)
- Allow those options in the yaml config as well


## TODO

- [x] remote `RemoteCommand` freezes the session for some reason
- [x] docs
- [x] example config