### PR TITLE
fix: parse config with Match

### DIFF
--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -42,7 +42,8 @@ be in either the SSH configuration format or YAML.
 
 It's also possible to serve the TUI over SSH using the server command.
 `,
-	Version: Version,
+	Version:      Version,
+	SilenceUsage: true,
 	CompletionOptions: coral.CompletionOptions{
 		HiddenDefaultCmd: true,
 	},

--- a/sshconfig/testdata/good
+++ b/sshconfig/testdata/good
@@ -1,3 +1,5 @@
+Match host app1 exec "echo hello"
+
 Host darkstar
   HostName darkstar.local
 


### PR DESCRIPTION
this is to avoid the upstream ssh_parse lib panicking.