### PR TITLE
fix: prefer specified identities instead of the ssh agent

### DIFF
--- a/client_auth.go
+++ b/client_auth.go
@@ -47,14 +47,15 @@ func remoteBestAuthMethod(s ssh.Session) (gossh.AuthMethod, agent.Agent, closers
 // It'll return a nil list if none of the methods is available.
 func localBestAuthMethod(agt agent.Agent, e *Endpoint) ([]gossh.AuthMethod, error) {
 	var methods []gossh.AuthMethod
-	if method := agentAuthMethod(agt); method != nil {
-		methods = append(methods, method)
-	}
-
 	if len(e.IdentityFiles) > 0 {
 		ids, err := tryIdendityFiles(e)
 		return append(methods, ids...), err
 	}
+
+	if method := agentAuthMethod(agt); method != nil {
+		methods = append(methods, method)
+	}
+
 	keys, err := tryUserKeys()
 	return append(methods, keys...), err
 }


### PR DESCRIPTION
if an identity file is provided, prefer it over the ssh agent.  