### PR TITLE
feat: allow to setenv and sendenv

### DIFF
--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -45,6 +45,11 @@ endpoints:
   # Defaults to true if remote_command is empty.
   request_tty: true
 
+  # Set environment variables into the connection.
+  environment:
+    - FOO=bar
+    - BAR=baz
+
 # users to allow access to the list
 users:
   -

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/muesli/termenv"
@@ -30,6 +31,15 @@ func createSession(conf *gossh.ClientConfig, e *Endpoint) (*gossh.Session, *goss
 		return nil, conn, cl, fmt.Errorf("failed to open session: %w", err)
 	}
 	cl = append(cl, session.Close)
+	for _, env := range e.Environment {
+		k, v, ok := strings.Cut(env, "=")
+		if ok && k != "" && v != "" {
+			if err := session.Setenv(k, v); err != nil {
+				return session, conn, cl, fmt.Errorf("could not set env: %q: %w", env, err)
+			}
+			log.Println("setenv", k)
+		}
+	}
 	return session, conn, cl, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Endpoint struct {
 	RemoteCommand string            `yaml:"remote_command"` // RemoteCommand defines wether to request a TTY. Anologous to SSH's config RemoteCommand.
 	Desc          string            `yaml:"description"`    // Description describes an optional description of the item.
 	Link          Link              `yaml:"link"`           // Links can be used to add a link to the item description using OSC8.
+	Environment   []string          `yaml:"environment"`    // Environment variables to be used with SendEnv and SetEnv
 	IdentityFiles []string          `yaml:"-"`              // IdentityFiles is only set when parsing from a SSH Config file, and used only on local mode.
 	Middlewares   []wish.Middleware `yaml:"-"`              // wish middlewares you can use in the factory method.
 }

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -25,6 +25,10 @@ func TestParseFile(t *testing.T) {
 				Name:    "supernova",
 				Address: "supernova.local:22",
 				User:    "notme",
+				Environment: []string{
+					"FOO=foo",
+					"BAR=bar",
+				},
 			},
 			{
 				Name:    "app1",
@@ -38,9 +42,10 @@ func TestParseFile(t *testing.T) {
 				ForwardAgent:  true,
 			},
 			{
-				Name:    "multiple1",
-				Address: "multi1.foo.local:22",
-				User:    "multi",
+				Name:        "multiple1",
+				Address:     "multi1.foo.local:22",
+				User:        "multi",
+				Environment: []string{"FOO=foobar"},
 			},
 			{
 				Name:    "multiple2",

--- a/sshconfig/testdata/good
+++ b/sshconfig/testdata/good
@@ -7,6 +7,12 @@ Host supernova
 	HostName supernova.local
 	User notme
 	ForwardAgent does-not-matter
+	SendEnv FOO
+	SendEnv BAR
+	SendEnv NOPE
+	SetEnv FOO=foo
+	SetEnv BAR=bar
+	SetEnv IGNR=nope
 
 Host app1
 	HostName app.foo.local
@@ -21,14 +27,18 @@ Host app2
 
 Host multiple1 multiple2 multiple3
 	User multi
+	SendEnv FOO
 
 Host multiple1
 	HostName multi1.foo.local
+	SetEnv FOO=foobar
+	SetEnv FOOS=foobar
 
 Host multiple2
 	HostName multi2.foo.local
 	Port 2223
 	ForwardAgent no
+	SetEnv FOOS=foobar
 
 ##############
 # HOME STUFF #
@@ -37,10 +47,13 @@ Host multiple2
 Host multiple3
 	HostName multi3.foo.local
 	User overridden
+	SetEnv AAA
+	SendEnv AAA
 
 Host no.hostname
 	Port 23231
 	ForwardAgent yes
+	SendEnv AAA
 
 Host only.host
 


### PR DESCRIPTION
- parse ssh config `SendEnv` and `SetEnv` 
- allow an `environment` config in the yaml
- passes environment variables into the session

closes #68 