### PR TITLE
feat: pass allowed env from parent connection

### DIFF
--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -46,9 +46,19 @@ endpoints:
   request_tty: true
 
   # Set environment variables into the connection.
-  environment:
+  # Analogous to SSH's SetEnv.
+  set_env:
     - FOO=bar
     - BAR=baz
+
+  # Environments from the environment that match these keys will also be set
+  # into the connection.
+  # Analogous to SSH's SendEnv.
+  # Defaults to LC_* and LANG.
+  send_env:
+    - LC_*
+    - LANG
+    - SOME_ENV
 
 # users to allow access to the list
 users:

--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -54,7 +54,7 @@ endpoints:
   # Environments from the environment that match these keys will also be set
   # into the connection.
   # Analogous to SSH's SendEnv.
-  # Defaults to LC_* and LANG.
+  # Defaults to ["LC_*", "LANG"].
   send_env:
     - LC_*
     - LANG

--- a/client.go
+++ b/client.go
@@ -34,7 +34,7 @@ func createSession(conf *gossh.ClientConfig, e *Endpoint, env ...string) (*gossh
 		if err := session.Setenv(k, v); err != nil {
 			return session, conn, cl, fmt.Errorf("could not set env: %q: %w", env, err)
 		}
-		log.Printf("setting env: %q=%q", k, v)
+		log.Printf("setting env %s = %q", k, v)
 	}
 	return session, conn, cl, nil
 }

--- a/client.go
+++ b/client.go
@@ -34,7 +34,7 @@ func createSession(conf *gossh.ClientConfig, e *Endpoint, env ...string) (*gossh
 		if err := session.Setenv(k, v); err != nil {
 			return session, conn, cl, fmt.Errorf("could not set env: %q: %w", env, err)
 		}
-		log.Println("setenv", k)
+		log.Printf("setting env: %q=%q", k, v)
 	}
 	return session, conn, cl, nil
 }

--- a/client_local.go
+++ b/client_local.go
@@ -74,7 +74,7 @@ func (s *localSession) Run() error {
 		HostKeyCallback: hostKeyCallback(s.endpoint, filepath.Join(user.HomeDir, ".ssh/known_hosts")),
 	}
 
-	session, client, cls, err := createSession(conf, s.endpoint)
+	session, client, cls, err := createSession(conf, s.endpoint, os.Environ()...)
 	defer cls.close()
 	if err != nil {
 		return fmt.Errorf("failed to create session: %w", err)

--- a/client_remote.go
+++ b/client_remote.go
@@ -64,7 +64,7 @@ func (s *remoteSession) Run() error {
 		HostKeyCallback: hostKeyCallback(s.endpoint, ".wishlist/known_hosts"),
 		Auth:            []gossh.AuthMethod{method},
 	}
-	session, client, cl, err := createSession(conf, s.endpoint)
+	session, client, cl, err := createSession(conf, s.endpoint, s.parentSession.Environ()...)
 	defer cl.close()
 	if err != nil {
 		return fmt.Errorf("failed to create session: %w", err)

--- a/config.go
+++ b/config.go
@@ -74,7 +74,7 @@ func (e Endpoint) Environment(hostenv ...string) map[string]string {
 }
 
 func (e Endpoint) shouldSend(k string) bool {
-	for _, send := range e.SendEnv {
+	for _, send := range append(e.SendEnv, "LC_*", "LANG") { // append default OpenSSH SendEnv's
 		glob, err := glob.Compile(send)
 		if err != nil {
 			continue

--- a/config.go
+++ b/config.go
@@ -52,7 +52,7 @@ func (e Endpoint) Environment(hostenv ...string) map[string]string {
 
 	for _, set := range hostenv {
 		k, v, ok := strings.Cut(set, "=")
-		if !ok {
+		if !ok || k == "" {
 			continue
 		}
 		if e.shouldSend(k) {
@@ -64,7 +64,7 @@ func (e Endpoint) Environment(hostenv ...string) map[string]string {
 
 	for _, set := range e.SetEnv {
 		k, v, ok := strings.Cut(set, "=")
-		if !ok {
+		if !ok || k == "" {
 			continue
 		}
 		env[k] = v

--- a/config_test.go
+++ b/config_test.go
@@ -63,35 +63,34 @@ func TestEnvironment(t *testing.T) {
 		{
 			name:     "no env",
 			endpoint: &Endpoint{},
-			env:      map[string]string{},
+			env: map[string]string{
+				"LC_ALL": "en_US.UTF-8",
+				"LANG":   "en_US",
+			},
 		},
 		{
 			name: "some invalid env",
 			endpoint: &Endpoint{
-				SendEnv: []string{
-					"FOO",
-					"BAR",
-					"NOPE",
-				},
+				SendEnv: []string{},
 				SetEnv: []string{
 					"FOO=foo",
 					"BAR",
 					"IGNR=",
+					"=ignr",
 				},
 			},
 			env: map[string]string{
-				"FOO":  "foo",
-				"IGNR": "",
+				"FOO":    "foo",
+				"IGNR":   "",
+				"LC_ALL": "en_US.UTF-8",
+				"LANG":   "en_US",
 			},
 		},
 		{
 			name: "some env",
 			endpoint: &Endpoint{
 				SendEnv: []string{
-					"FOO",
-					"BAR",
-					"NOPE",
-					"LC_*",
+					"FOO_*",
 				},
 				SetEnv: []string{
 					"FOO=foo",
@@ -99,14 +98,20 @@ func TestEnvironment(t *testing.T) {
 				},
 			},
 			env: map[string]string{
-				"BAR":    "bar",
-				"FOO":    "foo",
-				"LC_ALL": "en_US.UTF-8",
+				"BAR":     "bar",
+				"FOO":     "foo",
+				"LC_ALL":  "en_US.UTF-8",
+				"FOO_BAR": "foobar",
+				"LANG":    "en_US",
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.env, tt.endpoint.Environment("LC_ALL=en_US.UTF-8"))
+			require.Equal(t, tt.env, tt.endpoint.Environment(
+				"LC_ALL=en_US.UTF-8",
+				"LANG=en_US",
+				"FOO_BAR=foobar",
+			))
 		})
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -52,3 +52,61 @@ func TestShoudListen(t *testing.T) {
 		}.ShouldListen())
 	})
 }
+
+func TestEnvironment(t *testing.T) {
+	type testcase struct {
+		name     string
+		env      map[string]string
+		endpoint *Endpoint
+	}
+	for _, tt := range []testcase{
+		{
+			name:     "no env",
+			endpoint: &Endpoint{},
+			env:      map[string]string{},
+		},
+		{
+			name: "some invalid env",
+			endpoint: &Endpoint{
+				SendEnv: []string{
+					"FOO",
+					"BAR",
+					"NOPE",
+				},
+				SetEnv: []string{
+					"FOO=foo",
+					"BAR",
+					"IGNR=",
+				},
+			},
+			env: map[string]string{
+				"FOO":  "foo",
+				"IGNR": "",
+			},
+		},
+		{
+			name: "some env",
+			endpoint: &Endpoint{
+				SendEnv: []string{
+					"FOO",
+					"BAR",
+					"NOPE",
+					"LC_*",
+				},
+				SetEnv: []string{
+					"FOO=foo",
+					"BAR=bar",
+				},
+			},
+			env: map[string]string{
+				"BAR":    "bar",
+				"FOO":    "foo",
+				"LC_ALL": "en_US.UTF-8",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.env, tt.endpoint.Environment("LC_ALL=en_US.UTF-8"))
+		})
+	}
+}

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -68,7 +68,7 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 			RequestTTY:    stringToBool(info.RequestTTY),
 			RemoteCommand: info.RemoteCommand,
 			SetEnv:        info.SetEnv,
-			SendEnv:       append(info.SendEnv, "LC_*", "LANG"), // append default OpenSSH SendEnv's
+			SendEnv:       info.SendEnv,
 		})
 		return nil
 	}); err != nil {

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -68,7 +68,7 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 			RequestTTY:    stringToBool(info.RequestTTY),
 			RemoteCommand: info.RemoteCommand,
 			SetEnv:        info.SetEnv,
-			SendEnv:       info.SendEnv,
+			SendEnv:       append(info.SendEnv, "LC_*", "LANG"), // append default OpenSSH SendEnv's
 		})
 		return nil
 	}); err != nil {

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -56,18 +56,6 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 			return err
 		}
 
-		var env []string
-		for _, set := range info.SetEnv {
-			k, _, ok := strings.Cut(set, "=")
-			if !ok {
-				continue
-			}
-			for _, send := range info.SendEnv {
-				if send == k {
-					env = append(env, set)
-				}
-			}
-		}
 		endpoints = append(endpoints, &wishlist.Endpoint{
 			Name: name,
 			Address: net.JoinHostPort(
@@ -79,7 +67,8 @@ func ParseReader(r io.Reader) ([]*wishlist.Endpoint, error) {
 			ForwardAgent:  stringToBool(info.ForwardAgent),
 			RequestTTY:    stringToBool(info.RequestTTY),
 			RemoteCommand: info.RemoteCommand,
-			Environment:   env,
+			SetEnv:        info.SetEnv,
+			SendEnv:       info.SendEnv,
 		})
 		return nil
 	}); err != nil {

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -16,38 +16,35 @@ func TestParseFile(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, endpoints, 9)
-		require.Equal(t, []*wishlist.Endpoint{
-			{
+
+		results := map[string]*wishlist.Endpoint{
+			"darkstar": {
 				Name:    "darkstar",
 				Address: "darkstar.local:22",
 			},
-			{
+			"supernova": {
 				Name:    "supernova",
 				Address: "supernova.local:22",
 				User:    "notme",
 				SendEnv: []string{
 					"FOO",
-					"BAR",
-					"NOPE",
 				},
 				SetEnv: []string{
-					"FOO=foo",
 					"BAR=bar",
-					"IGNR=nope",
 				},
 			},
-			{
+			"app1": {
 				Name:    "app1",
 				Address: "app.foo.local:2222",
 			},
-			{
+			"app2": {
 				Name:          "app2",
 				Address:       "app.foo.local:2223",
 				User:          "someoneelse",
 				IdentityFiles: []string{"./testdata/key"},
 				ForwardAgent:  true,
 			},
-			{
+			"multiple1": {
 				Name:    "multiple1",
 				Address: "multi1.foo.local:22",
 				User:    "multi",
@@ -55,11 +52,10 @@ func TestParseFile(t *testing.T) {
 					"FOO",
 				},
 				SetEnv: []string{
-					"FOO=foobar",
 					"FOOS=foobar",
 				},
 			},
-			{
+			"multiple2": {
 				Name:    "multiple2",
 				Address: "multi2.foo.local:2223",
 				User:    "multi",
@@ -70,7 +66,7 @@ func TestParseFile(t *testing.T) {
 					"FOOS=foobar",
 				},
 			},
-			{
+			"multiple3": {
 				Name:    "multiple3",
 				Address: "multi3.foo.local:22",
 				User:    "overridden",
@@ -78,23 +74,23 @@ func TestParseFile(t *testing.T) {
 					"FOO",
 					"AAA",
 				},
-				SetEnv: []string{
-					"AAA",
-				},
 			},
-			{
+			"no.hostname": {
 				Name:         "no.hostname",
 				Address:      "no.hostname:23231",
 				ForwardAgent: true,
-				SendEnv: []string{
-					"AAA",
-				},
 			},
-			{
+			"only.host": {
 				Name:    "only.host",
 				Address: "only.host:22",
 			},
-		}, endpoints)
+		}
+
+		for _, e := range endpoints {
+			t.Run(e.Name, func(t *testing.T) {
+				require.Equal(t, results[e.Name], e)
+			})
+		}
 	})
 
 	t.Run("invalid node", func(t *testing.T) {

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -20,10 +20,6 @@ func TestParseFile(t *testing.T) {
 			{
 				Name:    "darkstar",
 				Address: "darkstar.local:22",
-				SendEnv: []string{
-					"LC_*",
-					"LANG",
-				},
 			},
 			{
 				Name:    "supernova",
@@ -33,8 +29,6 @@ func TestParseFile(t *testing.T) {
 					"FOO",
 					"BAR",
 					"NOPE",
-					"LC_*",
-					"LANG",
 				},
 				SetEnv: []string{
 					"FOO=foo",
@@ -45,10 +39,6 @@ func TestParseFile(t *testing.T) {
 			{
 				Name:    "app1",
 				Address: "app.foo.local:2222",
-				SendEnv: []string{
-					"LC_*",
-					"LANG",
-				},
 			},
 			{
 				Name:          "app2",
@@ -56,10 +46,6 @@ func TestParseFile(t *testing.T) {
 				User:          "someoneelse",
 				IdentityFiles: []string{"./testdata/key"},
 				ForwardAgent:  true,
-				SendEnv: []string{
-					"LC_*",
-					"LANG",
-				},
 			},
 			{
 				Name:    "multiple1",
@@ -67,8 +53,6 @@ func TestParseFile(t *testing.T) {
 				User:    "multi",
 				SendEnv: []string{
 					"FOO",
-					"LC_*",
-					"LANG",
 				},
 				SetEnv: []string{
 					"FOO=foobar",
@@ -81,8 +65,6 @@ func TestParseFile(t *testing.T) {
 				User:    "multi",
 				SendEnv: []string{
 					"FOO",
-					"LC_*",
-					"LANG",
 				},
 				SetEnv: []string{
 					"FOOS=foobar",
@@ -95,8 +77,6 @@ func TestParseFile(t *testing.T) {
 				SendEnv: []string{
 					"FOO",
 					"AAA",
-					"LC_*",
-					"LANG",
 				},
 				SetEnv: []string{
 					"AAA",
@@ -108,17 +88,11 @@ func TestParseFile(t *testing.T) {
 				ForwardAgent: true,
 				SendEnv: []string{
 					"AAA",
-					"LC_*",
-					"LANG",
 				},
 			},
 			{
 				Name:    "only.host",
 				Address: "only.host:22",
-				SendEnv: []string{
-					"LC_*",
-					"LANG",
-				},
 			},
 		}, endpoints)
 	})

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -20,6 +20,10 @@ func TestParseFile(t *testing.T) {
 			{
 				Name:    "darkstar",
 				Address: "darkstar.local:22",
+				SendEnv: []string{
+					"LC_*",
+					"LANG",
+				},
 			},
 			{
 				Name:    "supernova",
@@ -29,6 +33,8 @@ func TestParseFile(t *testing.T) {
 					"FOO",
 					"BAR",
 					"NOPE",
+					"LC_*",
+					"LANG",
 				},
 				SetEnv: []string{
 					"FOO=foo",
@@ -39,6 +45,10 @@ func TestParseFile(t *testing.T) {
 			{
 				Name:    "app1",
 				Address: "app.foo.local:2222",
+				SendEnv: []string{
+					"LC_*",
+					"LANG",
+				},
 			},
 			{
 				Name:          "app2",
@@ -46,6 +56,10 @@ func TestParseFile(t *testing.T) {
 				User:          "someoneelse",
 				IdentityFiles: []string{"./testdata/key"},
 				ForwardAgent:  true,
+				SendEnv: []string{
+					"LC_*",
+					"LANG",
+				},
 			},
 			{
 				Name:    "multiple1",
@@ -53,6 +67,8 @@ func TestParseFile(t *testing.T) {
 				User:    "multi",
 				SendEnv: []string{
 					"FOO",
+					"LC_*",
+					"LANG",
 				},
 				SetEnv: []string{
 					"FOO=foobar",
@@ -65,6 +81,8 @@ func TestParseFile(t *testing.T) {
 				User:    "multi",
 				SendEnv: []string{
 					"FOO",
+					"LC_*",
+					"LANG",
 				},
 				SetEnv: []string{
 					"FOOS=foobar",
@@ -77,6 +95,8 @@ func TestParseFile(t *testing.T) {
 				SendEnv: []string{
 					"FOO",
 					"AAA",
+					"LC_*",
+					"LANG",
 				},
 				SetEnv: []string{
 					"AAA",
@@ -88,11 +108,17 @@ func TestParseFile(t *testing.T) {
 				ForwardAgent: true,
 				SendEnv: []string{
 					"AAA",
+					"LC_*",
+					"LANG",
 				},
 			},
 			{
 				Name:    "only.host",
 				Address: "only.host:22",
+				SendEnv: []string{
+					"LC_*",
+					"LANG",
+				},
 			},
 		}, endpoints)
 	})
@@ -108,62 +134,6 @@ func TestParseFile(t *testing.T) {
 		require.Empty(t, endpoints)
 		require.ErrorIs(t, err, os.ErrNotExist)
 	})
-}
-
-func TestEnvironment(t *testing.T) {
-	type testcase struct {
-		name     string
-		env      map[string]string
-		endpoint *wishlist.Endpoint
-	}
-	for _, tt := range []testcase{
-		{
-			name:     "no env",
-			endpoint: &wishlist.Endpoint{},
-			env:      map[string]string{},
-		},
-		{
-			name: "some invalid env",
-			endpoint: &wishlist.Endpoint{
-				SendEnv: []string{
-					"FOO",
-					"BAR",
-					"NOPE",
-				},
-				SetEnv: []string{
-					"FOO=foo",
-					"BAR",
-					"IGNR=",
-				},
-			},
-			env: map[string]string{
-				"FOO": "foo",
-			},
-		},
-		{
-			name: "some env",
-			endpoint: &wishlist.Endpoint{
-				SendEnv: []string{
-					"FOO",
-					"BAR",
-					"NOPE",
-				},
-				SetEnv: []string{
-					"FOO=foo",
-					"BAR=bar",
-					"IGNR=nope",
-				},
-			},
-			env: map[string]string{
-				"BAR": "bar",
-				"FOO": "foo",
-			},
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.env, tt.endpoint.Environment())
-		})
-	}
 }
 
 func TestParseReader(t *testing.T) {

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -15,7 +15,7 @@ func TestParseFile(t *testing.T) {
 		endpoints, err := ParseFile("testdata/good")
 		require.NoError(t, err)
 
-		require.Len(t, endpoints, 9)
+		require.Len(t, endpoints, 11)
 
 		results := map[string]*wishlist.Endpoint{
 			"darkstar": {
@@ -83,6 +83,18 @@ func TestParseFile(t *testing.T) {
 			"only.host": {
 				Name:    "only.host",
 				Address: "only.host:22",
+			},
+
+			"req.tty": {
+				Name:       "req.tty",
+				Address:    "req.tty:22",
+				RequestTTY: true,
+			},
+
+			"remote.cmd": {
+				Name:          "remote.cmd",
+				Address:       "remote.cmd:22",
+				RemoteCommand: "tmux",
 			},
 		}
 

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -25,9 +25,15 @@ func TestParseFile(t *testing.T) {
 				Name:    "supernova",
 				Address: "supernova.local:22",
 				User:    "notme",
-				Environment: []string{
+				SendEnv: []string{
+					"FOO",
+					"BAR",
+					"NOPE",
+				},
+				SetEnv: []string{
 					"FOO=foo",
 					"BAR=bar",
+					"IGNR=nope",
 				},
 			},
 			{
@@ -42,25 +48,47 @@ func TestParseFile(t *testing.T) {
 				ForwardAgent:  true,
 			},
 			{
-				Name:        "multiple1",
-				Address:     "multi1.foo.local:22",
-				User:        "multi",
-				Environment: []string{"FOO=foobar"},
+				Name:    "multiple1",
+				Address: "multi1.foo.local:22",
+				User:    "multi",
+				SendEnv: []string{
+					"FOO",
+				},
+				SetEnv: []string{
+					"FOO=foobar",
+					"FOOS=foobar",
+				},
 			},
 			{
 				Name:    "multiple2",
 				Address: "multi2.foo.local:2223",
 				User:    "multi",
+				SendEnv: []string{
+					"FOO",
+				},
+				SetEnv: []string{
+					"FOOS=foobar",
+				},
 			},
 			{
 				Name:    "multiple3",
 				Address: "multi3.foo.local:22",
 				User:    "overridden",
+				SendEnv: []string{
+					"FOO",
+					"AAA",
+				},
+				SetEnv: []string{
+					"AAA",
+				},
 			},
 			{
 				Name:         "no.hostname",
 				Address:      "no.hostname:23231",
 				ForwardAgent: true,
+				SendEnv: []string{
+					"AAA",
+				},
 			},
 			{
 				Name:    "only.host",
@@ -80,6 +108,44 @@ func TestParseFile(t *testing.T) {
 		require.Empty(t, endpoints)
 		require.ErrorIs(t, err, os.ErrNotExist)
 	})
+}
+
+func TestEnvironment(t *testing.T) {
+	type testcase struct {
+		name     string
+		env      map[string]string
+		endpoint *wishlist.Endpoint
+	}
+	for _, tt := range []testcase{
+		{
+			name:     "no env",
+			endpoint: &wishlist.Endpoint{},
+			env:      map[string]string{},
+		},
+		{
+			name: "some env",
+			endpoint: &wishlist.Endpoint{
+				SendEnv: []string{
+					"FOO",
+					"BAR",
+					"NOPE",
+				},
+				SetEnv: []string{
+					"FOO=foo",
+					"BAR=bar",
+					"IGNR=nope",
+				},
+			},
+			env: map[string]string{
+				"BAR": "bar",
+				"FOO": "foo",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.env, tt.endpoint.Environment())
+		})
+	}
 }
 
 func TestParseReader(t *testing.T) {

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -123,6 +123,24 @@ func TestEnvironment(t *testing.T) {
 			env:      map[string]string{},
 		},
 		{
+			name: "some invalid env",
+			endpoint: &wishlist.Endpoint{
+				SendEnv: []string{
+					"FOO",
+					"BAR",
+					"NOPE",
+				},
+				SetEnv: []string{
+					"FOO=foo",
+					"BAR",
+					"IGNR=",
+				},
+			},
+			env: map[string]string{
+				"FOO": "foo",
+			},
+		},
+		{
 			name: "some env",
 			endpoint: &wishlist.Endpoint{
 				SendEnv: []string{

--- a/sshconfig/testdata/good
+++ b/sshconfig/testdata/good
@@ -48,6 +48,12 @@ Host no.hostname
 	Port 23231
 	ForwardAgent yes
 
+Host req.tty
+	RequestTTY yes
+
+Host remote.cmd
+	RemoteCommand tmux
+
 Host only.host
 
 

--- a/sshconfig/testdata/good
+++ b/sshconfig/testdata/good
@@ -8,11 +8,7 @@ Host supernova
 	User notme
 	ForwardAgent does-not-matter
 	SendEnv FOO
-	SendEnv BAR
-	SendEnv NOPE
-	SetEnv FOO=foo
 	SetEnv BAR=bar
-	SetEnv IGNR=nope
 
 Host app1
 	HostName app.foo.local
@@ -31,7 +27,6 @@ Host multiple1 multiple2 multiple3
 
 Host multiple1
 	HostName multi1.foo.local
-	SetEnv FOO=foobar
 	SetEnv FOOS=foobar
 
 Host multiple2
@@ -47,13 +42,11 @@ Host multiple2
 Host multiple3
 	HostName multi3.foo.local
 	User overridden
-	SetEnv AAA
 	SendEnv AAA
 
 Host no.hostname
 	Port 23231
 	ForwardAgent yes
-	SendEnv AAA
 
 Host only.host
 


### PR DESCRIPTION
refs #68 #70 

Make it better by splitting `SetEnv` and `SendEnv` in the YAML config as well, and properly handling `SetEnv` (it should set the env wether or not it is in `SendEnv`), as well as using `os.Environ()` and the parent's `session.Environ()` on clients (in that case allowing only the keys in `SendEnv`).

todo: 

- [x] pass parent's session env into the children session
- [x] do the same locally for allowed envs
- [x] patterns on env names

this will make it more like the openssh client.