### PR TITLE
fix: smarter list delegate height

### DIFF
--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -13,6 +13,15 @@ port: 2223
 
 # Endpoints to list in the UI.
 endpoints:
+- name: foo
+  address: foo:222
+- name: fooba
+  address: foo:222
+  description: desc
+- name: foobarrr
+  address: foo:3322
+  link:
+    url: https://fooo.bar
 -
   # Endpoint's name.
   # Recommended to avoid spaces so users can `ssh -t appname`.

--- a/listitem.go
+++ b/listitem.go
@@ -1,0 +1,49 @@
+package wishlist
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var noContentStyle = lipgloss.NewStyle().Faint(true).Italic(true)
+
+type ItemWrapper struct {
+	endpoint    *Endpoint
+	descriptors []descriptor
+}
+
+// FilterValue to abide the list.Item interface.
+func (i ItemWrapper) FilterValue() string { return i.endpoint.Name }
+
+// Title to abide the list.Item interface.
+func (i ItemWrapper) Title() string { return i.endpoint.Name }
+
+// Description to abide the list.Item interface.
+func (i ItemWrapper) Description() string {
+	var lines []string
+	for _, desc := range i.descriptors {
+		lines = append(lines, desc(i.endpoint))
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+type descriptor func(e *Endpoint) string
+
+func withSSHURL(i *Endpoint) string {
+	return Link{URL: "ssh://" + i.Address}.String()
+}
+
+func withLink(i *Endpoint) string {
+	if l := i.Link.String(); l != "" {
+		return l
+	}
+	return noContentStyle.Render("no link")
+}
+
+func withDescription(i *Endpoint) string {
+	if desc := strings.Split(i.Desc, "\n")[0]; desc != "" {
+		return desc
+	}
+	return noContentStyle.Render("no description")
+}

--- a/listitem.go
+++ b/listitem.go
@@ -3,10 +3,13 @@ package wishlist
 import (
 	"strings"
 
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/lipgloss"
 )
 
 var noContentStyle = lipgloss.NewStyle().Faint(true).Italic(true)
+
+var _ list.Item = ItemWrapper{}
 
 type ItemWrapper struct {
 	endpoint    *Endpoint
@@ -25,7 +28,7 @@ func (i ItemWrapper) Description() string {
 	for _, desc := range i.descriptors {
 		lines = append(lines, desc(i.endpoint))
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	return strings.Join(lines, "\n")
 }
 
 type descriptor func(e *Endpoint) string

--- a/listitem.go
+++ b/listitem.go
@@ -11,6 +11,7 @@ var noContentStyle = lipgloss.NewStyle().Faint(true).Italic(true)
 
 var _ list.Item = ItemWrapper{}
 
+// ItemWrapper wrappes an Endpoint and a set of descriptors and acts as a list.Item.
 type ItemWrapper struct {
 	endpoint    *Endpoint
 	descriptors []descriptor

--- a/listitem_test.go
+++ b/listitem_test.go
@@ -1,0 +1,104 @@
+package wishlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemWrapper(t *testing.T) {
+	s := ItemWrapper{
+		endpoint: &Endpoint{
+			Name: "name",
+			Desc: "desc",
+			Link: Link{
+				URL: "https://example.com",
+			},
+			Address: "foo.bar:22",
+		},
+		descriptors: []descriptor{
+			withDescription,
+			withLink,
+			withSSHURL,
+		},
+	}
+
+	require.Equal(t, "name", s.Title())
+	require.Equal(t, "name", s.FilterValue())
+	require.Equal(
+		t,
+		"desc\n\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\\n\x1b]8;;ssh://foo.bar:22\x1b\\ssh://foo.bar:22\x1b]8;;\x1b\\",
+		s.Description(),
+	)
+}
+
+func TestWithSSHURL(t *testing.T) {
+	require.Equal(
+		t,
+		"\x1b]8;;ssh://localhost:22\x1b\\ssh://localhost:22\x1b]8;;\x1b\\",
+		withSSHURL(&Endpoint{
+			Address: "localhost:22",
+		}),
+	)
+}
+
+func TestWithDescription(t *testing.T) {
+	t.Run("no description", func(t *testing.T) {
+		require.Equal(
+			t,
+			"\x1b[3;2mno description\x1b[0m",
+			withDescription(&Endpoint{}),
+		)
+	})
+	t.Run("multiline", func(t *testing.T) {
+		require.Equal(
+			t,
+			"foo",
+			withDescription(&Endpoint{
+				Desc: "foo\n\nbar\n\nsfsdfsd\n",
+			}),
+		)
+	})
+	t.Run("simple", func(t *testing.T) {
+		require.Equal(
+			t,
+			"foobar desc",
+			withDescription(&Endpoint{
+				Desc: "foobar desc",
+			}),
+		)
+	})
+}
+
+func TestWithLink(t *testing.T) {
+	t.Run("no link", func(t *testing.T) {
+		require.Equal(
+			t,
+			"\x1b[3;2mno link\x1b[0m",
+			withLink(&Endpoint{}),
+		)
+	})
+	t.Run("url only", func(t *testing.T) {
+		require.Equal(
+			t,
+			"\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\",
+			withLink(&Endpoint{
+				Link: Link{
+					URL: "https://example.com",
+				},
+			}),
+		)
+	})
+	t.Run("url and name", func(t *testing.T) {
+		require.Equal(
+			t,
+			"\x1b]8;;https://example.com\x1b\\example\x1b]8;;\x1b\\",
+			withLink(&Endpoint{
+				Link: Link{
+					Name: "example",
+					URL:  "https://example.com",
+				},
+			}),
+		)
+	})
+}

--- a/wishlist.go
+++ b/wishlist.go
@@ -122,7 +122,12 @@ func (m *ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if selectedItem == nil {
 				return m, nil
 			}
-			cmd := m.client.For(selectedItem.(*ItemWrapper).endpoint)
+			w, ok := selectedItem.(ItemWrapper)
+			if !ok {
+				// this should never happen
+				return m, nil
+			}
+			cmd := m.client.For(w.endpoint)
 			return m, tea.Exec(cmd, func(err error) tea.Msg {
 				return errMsg{err}
 			})

--- a/wishlist.go
+++ b/wishlist.go
@@ -55,7 +55,6 @@ func (m *ListModel) SetItems(endpoints []*Endpoint) tea.Cmd {
 }
 
 func features(endpoints []*Endpoint) []descriptor {
-	log.Println("features()")
 	var hasDesc bool
 	var hasLink bool
 	for _, endpoint := range endpoints {

--- a/wishlist_test.go
+++ b/wishlist_test.go
@@ -12,7 +12,10 @@ func TestEndointToListItems(t *testing.T) {
 			Name:    "name",
 			Address: "anything",
 		},
-	})
+		{
+			// invalid
+		},
+	}, nil)
 
 	require.Len(t, result, 1)
 	item := result[0]
@@ -30,5 +33,72 @@ func TestNewWishlist(t *testing.T) {
 		}, cl)
 		require.Len(t, lm.endpoints, 1)
 		require.Equal(t, lm.client, cl)
+	})
+}
+
+func TestFeatures(t *testing.T) {
+	t.Run("complete", func(t *testing.T) {
+		descriptors := features([]*Endpoint{
+			{
+				// invalid
+				Desc: "desc",
+			},
+			{
+				Name:    "foo",
+				Address: "foo:22",
+			},
+			{
+				Name:    "foo",
+				Address: "foo:22",
+				Desc:    "desc",
+			},
+			{
+				Name:    "foo",
+				Address: "foo:22",
+				Link: Link{
+					URL: "link",
+				},
+			},
+		})
+
+		require.Len(t, descriptors, 3)
+	})
+
+	t.Run("simple", func(t *testing.T) {
+		descriptors := features([]*Endpoint{
+			{
+				// invalid
+				Desc: "desc",
+			},
+			{
+				Name:    "foo",
+				Address: "foo:22",
+			},
+		})
+		require.Len(t, descriptors, 1)
+	})
+
+	t.Run("with desc", func(t *testing.T) {
+		descriptors := features([]*Endpoint{
+			{
+				Name:    "foo",
+				Address: "foo:22",
+				Desc:    "desc",
+			},
+		})
+		require.Len(t, descriptors, 2)
+	})
+
+	t.Run("with link", func(t *testing.T) {
+		descriptors := features([]*Endpoint{
+			{
+				Name:    "foo",
+				Address: "foo:22",
+				Link: Link{
+					URL: "url",
+				},
+			},
+		})
+		require.Len(t, descriptors, 2)
 	})
 }


### PR DESCRIPTION
When setting the items in the list, check which features we use (i.e. links, descriptions, etc), size up the items accordingly and show a placeholder in items missing any of those items.

###### Example with no extra features:
<img width="1502" alt="CleanShot 2022-06-09 at 12 04 04@2x" src="https://user-images.githubusercontent.com/245435/172879717-e7768bf7-bb14-4800-88c4-4be9826eae5b.png">

###### Example with all features and items missing some of them:
<img width="942" alt="image" src="https://user-images.githubusercontent.com/245435/172879614-43d8dae8-abce-4011-9d8f-0275929e27a9.png">


### TODO

- [ ] unit tests