### PR TITLE
feat: yaml accept identity_files in local mode

### DIFF
--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -37,9 +37,15 @@ endpoints:
   # Defaults to asking for a shell.
   remote_command: uptime -a
 
-  # Wether to forward the SSH agent.
+  # Whether to forward the SSH agent.
   # Will cause the connection to fail if no agent is available.
   forward_agent: true # forwards the ssh agent
+
+  # IdentityFiles to try to use to authorize.
+  # Only used in local mode.
+  identity_files:
+    - ~/.ssh/id_rsa
+    - ~/.ssh/id_ed25519
 
   # requests a TTY.
   # Defaults to true if remote_command is empty.

--- a/config.go
+++ b/config.go
@@ -30,14 +30,14 @@ type Endpoint struct {
 	Name          string            `yaml:"name"`           // Endpoint name.
 	Address       string            `yaml:"address"`        // Endpoint address in the `host:port` format, if empty, will be the same address as the list, increasing the port number.
 	User          string            `yaml:"user"`           // User to authenticate as.
-	ForwardAgent  bool              `yaml:"forward_agent"`  // ForwardAgent defines wether to forward the current agent. Anologous to SSH's config ForwardAgent.
-	RequestTTY    bool              `yaml:"request_tty"`    // RequestTTY defines wether to request a TTY. Anologous to SSH's config RequestTTY.
-	RemoteCommand string            `yaml:"remote_command"` // RemoteCommand defines wether to request a TTY. Anologous to SSH's config RemoteCommand.
+	ForwardAgent  bool              `yaml:"forward_agent"`  // ForwardAgent defines whether to forward the current agent. Anologous to SSH's config ForwardAgent.
+	RequestTTY    bool              `yaml:"request_tty"`    // RequestTTY defines whether to request a TTY. Anologous to SSH's config RequestTTY.
+	RemoteCommand string            `yaml:"remote_command"` // RemoteCommand defines whether to request a TTY. Anologous to SSH's config RemoteCommand.
 	Desc          string            `yaml:"description"`    // Description describes an optional description of the item.
 	Link          Link              `yaml:"link"`           // Links can be used to add a link to the item description using OSC8.
 	SendEnv       []string          `yaml:"send_env"`       // Anologous to SSH's SendEnv
 	SetEnv        []string          `yaml:"set_env"`        // Anologous to SSH's SetEnv
-	IdentityFiles []string          `yaml:"-"`              // IdentityFiles is only set when parsing from a SSH Config file, and used only on local mode.
+	IdentityFiles []string          `yaml:"identity_files"` // IdentityFiles is only used when in local mode.
 	Middlewares   []wish.Middleware `yaml:"-"`              // wish middlewares you can use in the factory method.
 }
 


### PR DESCRIPTION
The remote client does not use that field, wheter its set or not. Only the local client uses it. That said, it should be safe to allow it in the yaml config as well.

closes #60