### PR TITLE
fix: dont quit if filter is getting applied

### DIFF
--- a/wishlist.go
+++ b/wishlist.go
@@ -119,7 +119,7 @@ func (m *ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = nil
 			return m, nil
 		}
-		if key.Matches(msg, list.DefaultKeyMap().Quit) {
+		if key.Matches(msg, list.DefaultKeyMap().Quit) && !m.list.SettingFilter() {
 			m.quitting = true
 		}
 		if key.Matches(msg, enter) {


### PR DESCRIPTION
This fixes a small issue, where wishlist went in a quitting state, if the user pressed "esc" to cancel setting a filter.