### PR TITLE
fix: dont quit if filter is set

### DIFF
--- a/wishlist.go
+++ b/wishlist.go
@@ -124,7 +124,7 @@ func (m *ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = nil
 			return m, nil
 		}
-		if key.Matches(msg, list.DefaultKeyMap().Quit) && !m.list.SettingFilter() {
+		if key.Matches(msg, list.DefaultKeyMap().Quit) && !m.list.SettingFilter() && m.list.FilterState() != list.FilterApplied {
 			m.quitting = true
 		}
 		if key.Matches(msg, enter) {


### PR DESCRIPTION
I noticed a bug that prevented the clearing of a filter using "esc". 
The code could be simplified slightly if https://github.com/charmbracelet/bubbles/pull/98 gets merged. 
