### PR TITLE
fix: ignore if the tea app didnt report an exit status

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/muesli/termenv"
+	"golang.org/x/crypto/ssh"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -63,7 +64,7 @@ func shellAndWait(session *gossh.Session) error {
 	if err := session.Shell(); err != nil {
 		return fmt.Errorf("failed to start shell: %w", err)
 	}
-	if err := session.Wait(); err != nil {
+	if err := session.Wait(); err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
 		return fmt.Errorf("session failed: %w", err)
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -64,7 +64,11 @@ func shellAndWait(session *gossh.Session) error {
 	if err := session.Shell(); err != nil {
 		return fmt.Errorf("failed to start shell: %w", err)
 	}
-	if err := session.Wait(); err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
+	if err := session.Wait(); err != nil {
+		if errors.Is(err, &ssh.ExitMissingError{}) {
+			log.Println("exit was missing, assuming exit 0")
+			return nil
+		}
 		return fmt.Errorf("session failed: %w", err)
 	}
 	return nil


### PR DESCRIPTION
When using wishlist as a library for multiple tea apps, since the "return to the list" feature, it seems that the app might not properly exit the session, which causes it to display an error.

Its not an useful error anyway, so it should be safe to ignore it.