### PR TITLE
feat: make metrics optional

### DIFF
--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -83,6 +83,9 @@ users:
 
 # Setup the /metrics prometheus endpoint.
 metrics:
+  # Enable the metrics.
+  enabled: true
+
   # App name that will be used in the metrics.
   name: my-wishlist
 

--- a/config.go
+++ b/config.go
@@ -128,6 +128,7 @@ type User struct {
 
 // Metrics configuration.
 type Metrics struct {
+	Enabled bool   `yaml:"enabled"`
 	Name    string `yaml:"name"`
 	Address string `yaml:"address"`
 }

--- a/server.go
+++ b/server.go
@@ -58,13 +58,16 @@ func Serve(config *Config) error {
 			Middlewares: []wish.Middleware{
 				listingMiddleware(config, relay),
 				cmdsMiddleware(config.Endpoints),
-				promwish.Middleware(
-					FirstNonEmpty(config.Metrics.Address, "localhost:9222"),
-					FirstNonEmpty(config.Metrics.Name, "wishlist"),
-				),
 			},
 		},
 	}, config.Endpoints...) {
+		if endpoint.Name == "list" && config.Metrics.Enabled {
+			endpoint.Middlewares = append(endpoint.Middlewares, promwish.Middleware(
+				FirstNonEmpty(config.Metrics.Address, "localhost:9222"),
+				FirstNonEmpty(config.Metrics.Name, "wishlist"),
+			))
+		}
+
 		if !endpoint.Valid() || !endpoint.ShouldListen() {
 			continue
 		}


### PR DESCRIPTION
Hi, since 8e35697fff3174fdffc8e52e90503d3845830b42 wishlist always starts a metrics server. Adding metrics is an amazing idea, however not everyone needs that and therefore I'd like to propose to make this feature optional.  

If you want it enabled by default, I'd suggest to at least add a `disabled` option. 