### PR TITLE
feat: discover from DNS SRV records

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ Wishlist can also find nodes from DNS SRV records, on one or more domains.
 Run `wishlist --srv.domain {your domain}` to get started. You can repeat the
 flag for multiple domains.
 
+By default, Wishlist will set the name of the endpoint to the SRV target.
+You can, however, customize that with a TXT record in the following format:
+
+```
+wishlist.name full.address:22=thename
+```
+
+So, in this case, a SRV record pointing to `full.address` on port `22` will get
+the name `thename`.
+
 ### Using the binary
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ Otherwise, the services will simply be added to the list.
 
 Run `wishlist --help` to see all the options.
 
+### SRV records
+
+Wishlist can also find nodes from DNS SRV records, on one or more domains.
+
+Run `wishlist --srv.domain {your domain}` to get started. You can repeat the
+flag for multiple domains.
+
 ### Using the binary
 
 ```sh

--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -186,7 +186,7 @@ func getConfig(configFile string) (wishlist.Config, error) {
 	for _, domain := range srvDomains {
 		endpoints, err := srv.Endpoints(domain)
 		if err != nil {
-			return wishlist.Config{}, err
+			return wishlist.Config{}, err //nolint: wrapcheck
 		}
 		seed = append(seed, endpoints...)
 	}

--- a/srv/srv.go
+++ b/srv/srv.go
@@ -1,0 +1,30 @@
+package srv
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	"github.com/charmbracelet/wishlist"
+)
+
+// Endpoints returns the _ssh._tcp SRV records on the given domain as
+// Wishlist endpoints.
+func Endpoints(domain string) ([]*wishlist.Endpoint, error) {
+	log.Printf("discovering _ssh._tcp SRV records on domain %q...", domain)
+	_, srvs, err := net.LookupSRV("ssh", "tcp", domain)
+	if err != nil {
+		return nil, fmt.Errorf("srv: could not resolve %s: %w", domain, err)
+	}
+	result := make([]*wishlist.Endpoint, 0, len(srvs))
+	for _, entry := range srvs {
+		hostname := strings.TrimSuffix(entry.Target, ".")
+		port := fmt.Sprintf("%d", entry.Port)
+		result = append(result, &wishlist.Endpoint{
+			Name:    hostname,
+			Address: net.JoinHostPort(hostname, port),
+		})
+	}
+	return result, nil
+}

--- a/srv/srv_test.go
+++ b/srv/srv_test.go
@@ -1,0 +1,66 @@
+package srv
+
+import (
+	"net"
+	"testing"
+
+	"github.com/charmbracelet/wishlist"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromRecords(t *testing.T) {
+	t.Run("no txt records", func(t *testing.T) {
+		require.ElementsMatch(t, []*wishlist.Endpoint{
+			{
+				Name:    "foo.local",
+				Address: "foo.local:2222",
+			},
+			{
+				Name:    "foo.bar",
+				Address: "foo.bar:22",
+			},
+		}, fromRecords([]*net.SRV{
+			{
+				Target:   "foo.bar",
+				Port:     22,
+				Priority: 10,
+				Weight:   10,
+			},
+			{
+				Target:   "foo.local",
+				Port:     2222,
+				Priority: 10,
+				Weight:   10,
+			},
+		}, nil))
+	})
+
+	t.Run("with txt records", func(t *testing.T) {
+		require.ElementsMatch(t, []*wishlist.Endpoint{
+			{
+				Name:    "local-foo",
+				Address: "foo.local:2222",
+			},
+			{
+				Name:    "foobar",
+				Address: "foo.bar:22",
+			},
+		}, fromRecords([]*net.SRV{
+			{
+				Target:   "foo.bar",
+				Port:     22,
+				Priority: 10,
+				Weight:   10,
+			},
+			{
+				Target:   "foo.local",
+				Port:     2222,
+				Priority: 10,
+				Weight:   10,
+			},
+		}, []string{
+			"wishlist.name foo.bar:22=foobar",
+			"wishlist.name foo.local:2222=local-foo",
+		}))
+	})
+}

--- a/zeroconf/zeroconf.go
+++ b/zeroconf/zeroconf.go
@@ -17,7 +17,7 @@ const service = "_ssh._tcp"
 
 // Endpoints returns the found endpoints from zeroconf.
 func Endpoints(domain string, timeout time.Duration) ([]*wishlist.Endpoint, error) {
-	log.Printf("getting %s from zeroconf on domain %q...", service, domain)
+	log.Printf("discovering %s from zeroconf on domain %q...", service, domain)
 	r, err := zeroconf.NewResolver()
 	if err != nil {
 		return nil, fmt.Errorf("zeroconf: could not create resolver: %w", err)


### PR DESCRIPTION
allow to find entrypoints from `_ssh._tcp.DOMAIN` SRV records.

refs #135


---

to try it out, create a DNS entry in a domain you own, for example `_ssh._tcp.caarlos0.dev`. 
You can set any priorities and weights, wishlist will just list them all.
Then, you can use `dig` to verify it works, e.g.:

```sh
dig -t SRV _ssh._tcp.caarlos0.dev +short
1 1 22 s01.caarlos0.dev.                                                                                                                                                                                                                                             
10 2 2222 s01.caarlos0.dev.
```

You can also customize the name of the endpoints by adding TXT records to the domain root, e.g.:

```sh
dig -t TXT caarlos0.dev +short
"wishlist.name s01.caarlos0.dev:2222=confettysh"
```

Just make sure to use the format `wishlist.name {address}:{port}={name}`, and it should magically work.

And, to use it, run `wishlist --srv.domain caarlos0.dev`.

That's it :)