### PR TITLE
fix: warn if setenv fails instead of hard-erroring

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,7 +52,8 @@ func createSession(conf *gossh.ClientConfig, e *Endpoint, abort <-chan os.Signal
 	cl = append(cl, session.Close)
 	for k, v := range e.Environment(env...) {
 		if err := session.Setenv(k, v); err != nil {
-			return session, conn, cl, fmt.Errorf("could not set env: %s=%s: %w", k, v, err)
+			log.Warn("could not set env", "key", k, "value", v, "err", err)
+			continue
 		}
 		log.Info("setting env", "key", k, "value", v)
 	}


### PR DESCRIPTION
OpenSSH also seems to only warn (judging by several stackoverflow posts, couldn't reproduce) when setting an environment variable fails.

I believe we can do the same on wishlist.

This refs #151