### PR TITLE
fix: do not hard-error if included file does not exist

### DIFF
--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -3,6 +3,7 @@ package sshconfig
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -222,6 +223,9 @@ func parseInternal(r io.Reader) (*hostinfoMap, error) {
 					}
 					included, err := parseFileInternal(path)
 					if err != nil {
+						if errors.Is(err, os.ErrNotExist) {
+							continue
+						}
 						return nil, err
 					}
 					infos.set(name, info)


### PR DESCRIPTION
OpenSSH doesn't error on it... so we might ignore it as well...