### PR TITLE
feat: support keyboard-interactive

### DIFF
--- a/client_auth.go
+++ b/client_auth.go
@@ -24,8 +24,8 @@ var errNoRemoteAgent = fmt.Errorf("no agent forwarded")
 // remoteBestAuthMethod returns an auth method.
 //
 // it first tries to use ssh-agent, if that's not available, it creates and uses a new key pair.
-func remoteBestAuthMethod(s ssh.Session, out io.Writer, in io.Reader) ([]gossh.AuthMethod, agent.Agent, closers, error) {
-	kb := keyboardInteractiveAuth(in, out)
+func remoteBestAuthMethod(s ssh.Session, in io.Reader) ([]gossh.AuthMethod, agent.Agent, closers, error) {
+	kb := keyboardInteractiveAuth(in, s)
 	method, agt, cls, err := tryRemoteAuthAgent(s)
 	if err != nil || method != nil {
 		return []gossh.AuthMethod{method, kb}, agt, cls, err

--- a/client_auth.go
+++ b/client_auth.go
@@ -298,3 +298,7 @@ func hostKeyCallback(e *Endpoint, path string) gossh.HostKeyCallback {
 		return nil
 	}
 }
+
+func noChallengeKeyboardInteractiveMethod(_, _ string, _ []string, _ []bool) ([]string, error) {
+	return nil, nil
+}

--- a/client_auth.go
+++ b/client_auth.go
@@ -3,6 +3,7 @@ package wishlist
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/charmbracelet/ssh"
 	"github.com/charmbracelet/wish"
 	"github.com/charmbracelet/wishlist/home"
+	"github.com/muesli/termenv"
 	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -23,14 +25,15 @@ var errNoRemoteAgent = fmt.Errorf("no agent forwarded")
 // remoteBestAuthMethod returns an auth method.
 //
 // it first tries to use ssh-agent, if that's not available, it creates and uses a new key pair.
-func remoteBestAuthMethod(s ssh.Session) (gossh.AuthMethod, agent.Agent, closers, error) {
+func remoteBestAuthMethod(s ssh.Session, out io.Writer, in io.Reader) ([]gossh.AuthMethod, agent.Agent, closers, error) {
+	kb := keyboardInteractiveAuth(in, out)
 	method, agt, cls, err := tryRemoteAuthAgent(s)
 	if err != nil || method != nil {
-		return method, agt, cls, err
+		return []gossh.AuthMethod{method, kb}, agt, cls, err
 	}
 
 	method, err = tryNewKey()
-	return method, nil, nil, err
+	return []gossh.AuthMethod{method, kb}, nil, nil, err
 }
 
 // localBestAuthMethod figures out which authentication method is the best for
@@ -57,9 +60,7 @@ func localBestAuthMethod(agt agent.Agent, e *Endpoint) ([]gossh.AuthMethod, erro
 		methods = append(methods, method)
 	}
 
-	if len(methods) > 0 {
-		return methods, nil
-	}
+	methods = append(methods, keyboardInteractiveAuth(os.Stdin, os.Stdout))
 
 	keys, err := tryUserKeys()
 	return append(methods, keys...), err
@@ -124,7 +125,7 @@ func tryRemoteAuthAgent(s ssh.Session) (gossh.AuthMethod, agent.Agent, closers, 
 	agent, closers, err := getRemoteAgent(s)
 	if err != nil {
 		if errors.Is(err, errNoRemoteAgent) {
-			wish.Error(s, fmt.Errorf("wishlist: ssh agent not available"))
+			wish.Errorln(s, fmt.Errorf("wishlist: ssh agent not available"))
 			return nil, nil, closers, nil
 		}
 		return nil, nil, closers, err
@@ -299,6 +300,31 @@ func hostKeyCallback(e *Endpoint, path string) gossh.HostKeyCallback {
 	}
 }
 
-func noChallengeKeyboardInteractiveMethod(_, _ string, _ []string, _ []bool) ([]string, error) {
-	return nil, nil
+// keyboardInteractiveAuth implements keyboard interactive authentication.
+func keyboardInteractiveAuth(in io.Reader, out io.Writer) gossh.AuthMethod {
+	scan := func(q string, echo bool) (string, error) {
+		fmt.Fprint(out, q+" ")
+		var answer string
+		if !echo {
+			fmt.Fprint(out, termenv.CSI+"8m")
+			defer fmt.Fprint(out, termenv.CSI+"28m")
+		}
+		if _, err := fmt.Fscan(in, &answer); err != nil {
+			return "", fmt.Errorf("could not scan: %w", err)
+		}
+		fmt.Fprintln(out)
+		return answer, nil
+	}
+	return gossh.KeyboardInteractive(func(name, instruction string, questions []string, echos []bool) (answers []string, err error) {
+		fmt.Fprintln(out, name)
+		fmt.Fprintln(out, instruction)
+		for i, q := range questions {
+			answer, err := scan(q, echos[i])
+			if err != nil {
+				return nil, err
+			}
+			answers = append(answers, answer)
+		}
+		return answers, nil
+	})
 }

--- a/client_remote.go
+++ b/client_remote.go
@@ -52,10 +52,9 @@ func (s *remoteSession) Run() error {
 	}
 	resetPty(s.parentSession)
 
-	stderr := s.parentSession.Stderr()
 	stdin := blocking.New(s.stdin)
 
-	method, agt, closers, err := remoteBestAuthMethod(s.parentSession, stderr, stdin)
+	method, agt, closers, err := remoteBestAuthMethod(s.parentSession, stdin)
 	if err != nil {
 		return fmt.Errorf("failed to find an auth method: %w", err)
 	}

--- a/client_remote.go
+++ b/client_remote.go
@@ -52,6 +52,7 @@ func (s *remoteSession) Run() error {
 	}
 	resetPty(s.parentSession)
 
+	kbMethod := gossh.KeyboardInteractive(noChallengeKeyboardInteractiveMethod)
 	method, agt, closers, err := remoteBestAuthMethod(s.parentSession)
 	if err != nil {
 		return fmt.Errorf("failed to find an auth method: %w", err)
@@ -61,7 +62,7 @@ func (s *remoteSession) Run() error {
 	conf := &gossh.ClientConfig{
 		User:            FirstNonEmpty(s.endpoint.User, s.parentSession.User()),
 		HostKeyCallback: hostKeyCallback(s.endpoint, ".wishlist/known_hosts"),
-		Auth:            []gossh.AuthMethod{method},
+		Auth:            []gossh.AuthMethod{method, kbMethod},
 		Timeout:         s.endpoint.Timeout,
 	}
 	session, client, cl, err := createSession(conf, s.endpoint, nil, s.parentSession.Environ()...)


### PR DESCRIPTION
This PR adds keyboard-interactive auth method to both local and remote clients.


**Limitations**:

- remote client will never echo anything because stdin is not in fact the stdin, but the parent's session stdin, which we don't have a `fd` for. It looks like [this](https://cln.sh/Dl8DJGr4)


refs #186 