### PR TITLE
feat: hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,20 +201,30 @@ Run `wishlist --help` to see all the options.
 
 ### SRV records
 
-Wishlist can also find nodes from DNS SRV records, on one or more domains.
+Wishlist can also find nodes from DNS `SRV` records, on one or more domains.
 
 Run `wishlist --srv.domain {your domain}` to get started. You can repeat the
 flag for multiple domains.
 
-By default, Wishlist will set the name of the endpoint to the SRV target.
-You can, however, customize that with a TXT record in the following format:
+By default, Wishlist will set the name of the endpoint to the `SRV` target.
+You can, however, customize that with a `TXT` record in the following format:
 
 ```
 wishlist.name full.address:22=thename
 ```
 
-So, in this case, a SRV record pointing to `full.address` on port `22` will get
+So, in this case, a `SRV` record pointing to `full.address` on port `22` will get
 the name `thename`.
+
+Run `wishlist --help` to see all the options.
+
+### Hints
+
+You can use the `hints` key in the YAML configuration file to hint settings into
+discovered endpoints.
+
+Check the [example configuration file](/_example/config.yaml) to learn
+what options are available.
 
 ### Using the binary
 

--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -67,6 +67,68 @@ endpoints:
       - LANG
       - SOME_ENV
 
+# Hints can be used to hint settings into discovered endpoints.
+#
+# You can use it to change the user, port, set remote commands, etc.
+#
+# A host can match multiple hints, in which all matched hints will be applied,
+# the last one having the priority.
+hints:
+  - #
+    # Glob to be used to match the discovered names.
+    match: "*.local"
+
+    # SSH port to use.
+    port: 23234
+
+    # URL to be printed in the list.
+    link:
+      name: Optional link name
+      url: https://github.com/charmbracelet/wishlist
+
+    # Descripton of the item.
+    description: "A description of this endpoint.\nCan have multiple lines."
+
+    # User to use to connect.
+    # Defaults to the current remote user.
+    user: notme
+
+    # Command to run against the remote address.
+    # Defaults to asking for a shell.
+    remote_command: uptime -a
+
+    # Whether to forward the SSH agent.
+    # Will cause the connection to fail if no agent is available.
+    forward_agent: true # forwards the ssh agent
+
+    # IdentityFiles to try to use to authorize.
+    # Only used in local mode.
+    identity_files:
+      - ~/.ssh/id_rsa
+      - ~/.ssh/id_ed25519
+
+    # Requests a TTY.
+    # Defaults to true if remote_command is empty.
+    request_tty: true
+
+    # Connection timeout.
+    connect_timeout: 10s
+
+    # Set environment variables into the connection.
+    # Analogous to SSH's SetEnv.
+    set_env:
+      - FOO=bar
+      - BAR=baz
+
+    # Environments from the environment that match these keys will also be set
+    # into the connection.
+    # Analogous to SSH's SendEnv.
+    # Defaults to ["LC_*", "LANG"].
+    send_env:
+      - LC_*
+      - LANG
+      - SOME_ENV
+
 # Users to allow access to the list
 users:
   - # User login

--- a/config.go
+++ b/config.go
@@ -54,6 +54,24 @@ type Endpoint struct {
 	Middlewares              []wish.Middleware `yaml:"-"`                         // wish middlewares you can use in the factory method.
 }
 
+// EndpointHint can be used to match a discovered endpoint (through zeroconf
+// for example) and set additional options into it.
+type EndpointHint struct {
+	Match                    string        `yaml:"match"`
+	Port                     string        `yaml:"port"`
+	User                     string        `yaml:"user"`
+	ForwardAgent             *bool         `yaml:"forward_agent"`
+	RequestTTY               *bool         `yaml:"request_tty"`
+	RemoteCommand            string        `yaml:"remote_command"`
+	Desc                     string        `yaml:"description"`
+	Link                     Link          `yaml:"link"`
+	SendEnv                  []string      `yaml:"send_env"`
+	SetEnv                   []string      `yaml:"set_env"`
+	PreferredAuthentications []string      `yaml:"preferred_authentications"`
+	IdentityFiles            []string      `yaml:"identity_files"`
+	Timeout                  time.Duration `yaml:"connect_timeout"`
+}
+
 // Authentications returns either the client preferred authentications or the
 // default publickey,keyboard-interactive
 func (e Endpoint) Authentications() []string {
@@ -128,6 +146,7 @@ type Config struct {
 	Listen       string                              `yaml:"listen"`    // Address to listen on.
 	Port         int64                               `yaml:"port"`      // Port to start the first server on.
 	Endpoints    []*Endpoint                         `yaml:"endpoints"` // Endpoints to list.
+	Hints        []EndpointHint                      `yaml:"hints"`     // Endpoints hints to apply to discovered hosts.
 	Factory      func(Endpoint) (*ssh.Server, error) `yaml:"-"`         // Factory used to create the SSH server for the given endpoint.
 	Users        []User                              `yaml:"users"`     // Users allowed to access the list.
 	Metrics      Metrics                             `yaml:"metrics"`   // Metrics configuration.


### PR DESCRIPTION
Hints can be used to "hint" options into endpoints discovered though other means, for instance, zeroconf.

Wishlist will match the `hint.match` (as a glob) against the discovered endpoints' names, and will apply the given settings to said endpoints.

It'll only apply to discovered endpoints, and will not affect other endpoints.

This can only be set via YAML configuration.