### PR TITLE
fix: use context on zeroconf and srv

### DIFF
--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -318,14 +318,14 @@ func getSeedEndpoints(ctx context.Context) ([]*wishlist.Endpoint, error) {
 		seed = append(seed, endpoints...)
 	}
 	if zeroconfEnabled {
-		endpoints, err := zeroconf.Endpoints(zeroconfDomain, zeroconfTimeout)
+		endpoints, err := zeroconf.Endpoints(ctx, zeroconfDomain, zeroconfTimeout)
 		if err != nil {
 			return nil, err //nolint: wrapcheck
 		}
 		seed = endpoints
 	}
 	for _, domain := range srvDomains {
-		endpoints, err := srv.Endpoints(domain)
+		endpoints, err := srv.Endpoints(ctx, domain)
 		if err != nil {
 			return nil, err //nolint: wrapcheck
 		}

--- a/srv/srv.go
+++ b/srv/srv.go
@@ -1,6 +1,7 @@
 package srv
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -11,13 +12,13 @@ import (
 
 // Endpoints returns the _ssh._tcp SRV records on the given domain as
 // Wishlist endpoints.
-func Endpoints(domain string) ([]*wishlist.Endpoint, error) {
+func Endpoints(ctx context.Context, domain string) ([]*wishlist.Endpoint, error) {
 	log.Info("discovering _ssh._tcp SRV records", "domain", domain)
-	_, srvs, err := net.LookupSRV("ssh", "tcp", domain)
+	_, srvs, err := net.DefaultResolver.LookupSRV(ctx, "ssh", "tcp", domain)
 	if err != nil {
 		return nil, fmt.Errorf("srv: could not resolve %s: %w", domain, err)
 	}
-	txts, err := net.LookupTXT(domain)
+	txts, err := net.DefaultResolver.LookupTXT(ctx, domain)
 	if err != nil {
 		return nil, fmt.Errorf("srv: could not resolve %s: %w", domain, err)
 	}

--- a/zeroconf/zeroconf.go
+++ b/zeroconf/zeroconf.go
@@ -16,13 +16,14 @@ import (
 const service = "_ssh._tcp"
 
 // Endpoints returns the found endpoints from zeroconf.
-func Endpoints(domain string, timeout time.Duration) ([]*wishlist.Endpoint, error) {
+func Endpoints(ctx context.Context, domain string, timeout time.Duration) ([]*wishlist.Endpoint, error) {
 	log.Info("discovering from zeroconf", "service", service, "domain", domain)
 	r, err := zeroconf.NewResolver()
 	if err != nil {
 		return nil, fmt.Errorf("zeroconf: could not create resolver: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	entries := make(chan *zeroconf.ServiceEntry)


### PR DESCRIPTION
using the cobra's context down into zeroconf and srv discoveries