### PR TITLE
feat: ProxyJump support

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
@@ -17,16 +18,62 @@ type SSHClient interface {
 	For(e *Endpoint) tea.ExecCommand
 }
 
+func proxyJump(addr, nextAddr string, conf, nextConf *gossh.ClientConfig) (*gossh.Client, closers, error) {
+	var cl closers
+	log.Info("connecting client to ProxyJump", "addr", addr)
+	jumpClient, err := gossh.Dial("tcp", addr, conf)
+	if err != nil {
+		return nil, cl, fmt.Errorf("connection to ProxyJump (%q) failed: %w", addr, err)
+	}
+	cl = append(cl, jumpClient.Close)
+
+	log.Info("connecting to target using jump client", "addr", nextAddr)
+	jumpConn, err := jumpClient.Dial("tcp", nextAddr)
+	if err != nil {
+		return nil, cl, fmt.Errorf("connection from ProxyJump (%q) to Host (%q) failed: %w", addr, nextAddr, err)
+	}
+	cl = append(cl, jumpConn.Close)
+
+	log.Info("getting client connection", "addr", nextAddr)
+	ncc, chans, reqs, err := gossh.NewClientConn(jumpConn, nextAddr, nextConf)
+	if err != nil {
+		return nil, cl, fmt.Errorf("client connection from ProxyJump (%q) to Host (%q) failed: %w", addr, nextAddr, err)
+	}
+	cl = append(cl, ncc.Close)
+
+	return gossh.NewClient(ncc, chans, reqs), cl, nil
+}
+
 func createSession(conf *gossh.ClientConfig, e *Endpoint, abort <-chan os.Signal, env ...string) (*gossh.Session, *gossh.Client, closers, error) {
 	var cl closers
 	var conn *gossh.Client
 	var err error
 	connected := make(chan bool, 1)
 
-	go func() {
-		conn, err = gossh.Dial("tcp", e.Address, conf)
-		connected <- true
-	}()
+	if jump := e.ProxyJump; jump == "" {
+		go func() {
+			conn, err = gossh.Dial("tcp", e.Address, conf)
+			connected <- true
+		}()
+	} else {
+		jumpConf := &gossh.ClientConfig{
+			User:            conf.User,
+			Auth:            conf.Auth,
+			HostKeyCallback: conf.HostKeyCallback,
+		}
+		username, addr, ok := strings.Cut(jump, "@")
+		if ok {
+			jumpConf.User = username
+		} else {
+			addr = jump
+		}
+		log.Info("ProxyJump", "jump", jump, "addr", addr, "user", jumpConf.User)
+
+		go func() {
+			conn, cl, err = proxyJump(addr, e.Address, jumpConf, conf)
+			connected <- true
+		}()
+	}
 
 	select {
 	case <-connected:
@@ -34,9 +81,9 @@ func createSession(conf *gossh.ClientConfig, e *Endpoint, abort <-chan os.Signal
 		break
 	case <-abort:
 		if conn != nil {
-			_ = conn.Close()
+			cl = append(cl, conn.Close)
 		}
-		return nil, nil, nil, fmt.Errorf("connection aborted")
+		return nil, nil, cl, fmt.Errorf("connection aborted")
 	}
 
 	if err != nil {

--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -267,6 +267,9 @@ func applyHints(seed []*wishlist.Endpoint, hints []wishlist.EndpointHint) []*wis
 			if s := hint.Link; !reflect.DeepEqual(s, wishlist.Link{}) {
 				end.Link = s
 			}
+			if s := hint.ProxyJump; s != "" {
+				end.ProxyJump = s
+			}
 			end.SendEnv = append(end.SendEnv, hint.SendEnv...)
 			end.SetEnv = append(end.SetEnv, hint.SetEnv...)
 			end.PreferredAuthentications = append(end.PreferredAuthentications, hint.PreferredAuthentications...)

--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type Endpoint struct {
 	RemoteCommand            string            `yaml:"remote_command"`            // RemoteCommand defines whether to request a TTY. Anologous to SSH's config RemoteCommand.
 	Desc                     string            `yaml:"description"`               // Description describes an optional description of the item.
 	Link                     Link              `yaml:"link"`                      // Links can be used to add a link to the item description using OSC8.
+	ProxyJump                string            `yaml:"proxy_jump"`                // Anologous to SSH's ProxyJump
 	SendEnv                  []string          `yaml:"send_env"`                  // Anologous to SSH's SendEnv
 	SetEnv                   []string          `yaml:"set_env"`                   // Anologous to SSH's SetEnv
 	PreferredAuthentications []string          `yaml:"preferred_authentications"` // Anologous to SSH's PreferredAuthentications
@@ -65,6 +66,7 @@ type EndpointHint struct {
 	RemoteCommand            string        `yaml:"remote_command"`
 	Desc                     string        `yaml:"description"`
 	Link                     Link          `yaml:"link"`
+	ProxyJump                string        `yaml:"proxy_jump"`
 	SendEnv                  []string      `yaml:"send_env"`
 	SetEnv                   []string      `yaml:"set_env"`
 	PreferredAuthentications []string      `yaml:"preferred_authentications"`

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -74,6 +74,7 @@ func ParseReader(r io.Reader, seed []*wishlist.Endpoint) ([]*wishlist.Endpoint, 
 			SetEnv:                   info.SetEnv,
 			SendEnv:                  info.SendEnv,
 			PreferredAuthentications: info.PreferredAuthentications,
+			ProxyJump:                info.ProxyJump,
 		})
 		return nil
 	}); err != nil {
@@ -96,6 +97,7 @@ type hostinfo struct {
 	ForwardAgent             string
 	RequestTTY               string
 	RemoteCommand            string
+	ProxyJump                string
 	SendEnv                  []string
 	SetEnv                   []string
 	PreferredAuthentications []string
@@ -208,6 +210,8 @@ func parseInternal(r io.Reader) (*hostinfoMap, error) {
 					info.RequestTTY = value
 				case "RemoteCommand":
 					info.RemoteCommand = value
+				case "ProxyJump":
+					info.ProxyJump = value
 				case "ConnectTimeout":
 					timeout, err := strconv.Atoi(value)
 					if err != nil {
@@ -312,6 +316,9 @@ func mergeHostinfo(h1, h2 hostinfo) hostinfo {
 	}
 	if h1.Timeout > 0 {
 		h2.Timeout = h1.Timeout
+	}
+	if h1.ProxyJump != "" {
+		h2.ProxyJump = h1.ProxyJump
 	}
 	h2.SendEnv = append(h2.SendEnv, h1.SendEnv...)
 	h2.SetEnv = append(h2.SetEnv, h1.SetEnv...)

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -35,6 +35,7 @@ func TestParseFile(t *testing.T) {
 					"publickey",
 					"hostbased",
 				},
+				ProxyJump: "user@host:port",
 				SendEnv: []string{
 					"FOO",
 				},
@@ -302,7 +303,7 @@ func TestHostinfoMap(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, order)
 
 	expectedErr := fmt.Errorf("some error")
-	require.Equal(t, expectedErr, m.forEach(func(s string, h hostinfo, e error) error {
+	require.Equal(t, expectedErr, m.forEach(func(s string, _ hostinfo, e error) error {
 		if e != nil {
 			return e
 		}

--- a/sshconfig/testdata/good
+++ b/sshconfig/testdata/good
@@ -10,7 +10,8 @@ Host supernova
 	SendEnv FOO
 	SetEnv BAR=bar
 	ConnectTimeout 20
-  PreferredAuthentications password,keyboard-interactive,publickey,hostbased
+	PreferredAuthentications password,keyboard-interactive,publickey,hostbased
+	ProxyJump user@host:port
 
 Host app1
 	HostName app.foo.local


### PR DESCRIPTION
This adds `ProxyJump` support to Wishlist!

ProxyCommand is still not supported as we don't use the system's `ssh` binary, so implementing it is a bit more cumbersome.

refs #146