### PR TITLE
fix: sshconfig parse: lowercase keys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
     commit-message:
       prefix: "feat"
       include: "scope"
-    groups:
-      gomod:
-        patterns:
-          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -22,10 +18,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -195,36 +195,36 @@ func parseInternal(r io.Reader) (*hostinfoMap, error) {
 				key := strings.TrimSpace(parts[0])
 				value := strings.TrimSpace(parts[1])
 
-				switch key {
-				case "HostName":
+				switch strings.ToLower(key) {
+				case "hostname":
 					info.Hostname = value
-				case "User":
+				case "user":
 					info.User = value
-				case "Port":
+				case "port":
 					info.Port = value
-				case "IdentityFile":
+				case "identityfile":
 					info.IdentityFiles = append(info.IdentityFiles, value)
-				case "ForwardAgent":
+				case "forwardagent":
 					info.ForwardAgent = value
-				case "RequestTTY":
+				case "requesttty":
 					info.RequestTTY = value
-				case "RemoteCommand":
+				case "remotecommand":
 					info.RemoteCommand = value
-				case "ProxyJump":
+				case "proxyjump":
 					info.ProxyJump = value
-				case "ConnectTimeout":
+				case "connecttimeout":
 					timeout, err := strconv.Atoi(value)
 					if err != nil {
 						return nil, fmt.Errorf("invalid ConnectTimeout: %s: %w", value, err)
 					}
 					info.Timeout = time.Second * time.Duration(timeout)
-				case "SendEnv":
+				case "sendenv":
 					info.SendEnv = append(info.SendEnv, value)
-				case "SetEnv":
+				case "setenv":
 					info.SetEnv = append(info.SetEnv, value)
-				case "PreferredAuthentications":
+				case "preferredauthentications":
 					info.PreferredAuthentications = append(info.PreferredAuthentications, strings.Split(value, ",")...)
-				case "Include":
+				case "include":
 					path, err := home.ExpandPath(value)
 					if err != nil {
 						return nil, err //nolint: wrapcheck

--- a/sshconfig/testdata/good
+++ b/sshconfig/testdata/good
@@ -4,8 +4,8 @@ Host darkstar
 	HostName darkstar.local
 
 Host supernova
-	HostName supernova.local
-	User notme
+	Hostname supernova.local
+	uSer notme
 	ForwardAgent does-not-matter
 	SendEnv FOO
 	SetEnv BAR=bar


### PR DESCRIPTION
fixes #207


we're checking strictly `HostName`, so `Hostname` wasn't getting parsed properly.

This lowercases the key and checks it against the lowercased keywords, which seems more similar to what openssh does.