### PR TITLE
fix: race condition in server mode

### DIFF
--- a/multiplex/reader.go
+++ b/multiplex/reader.go
@@ -62,7 +62,7 @@ var (
 
 type syncWriter struct {
 	b  bytes.Buffer
-	mu sync.RWMutex
+	mu sync.Mutex
 }
 
 // Reset implements ResetableReader.
@@ -74,8 +74,8 @@ func (w *syncWriter) Reset() {
 
 // Read implements io.Reader.
 func (w *syncWriter) Read(p []byte) (n int, err error) {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.b.Read(p) //nolint: wrapcheck
 }
 


### PR DESCRIPTION
`sync.RWMutex` allows concurrent reads, which apparently the inner `bytes.Buffer` don't, and wishlist was triggering sometimes. 

So, changing to a `sync.Mutex` thus locking all ops fixes it.

Thanks @aymanbagabas for reporting this!