### PR TITLE
feat(tailscale): update hostname to device name

### DIFF
--- a/tailscale/tailscale.go
+++ b/tailscale/tailscale.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/charmbracelet/wishlist"
@@ -58,7 +59,7 @@ func Endpoints(ctx context.Context, tailnet, key, clientID, clientSecret string)
 	endpoints := make([]*wishlist.Endpoint, 0, len(devices.Devices))
 	for _, device := range devices.Devices {
 		endpoints = append(endpoints, &wishlist.Endpoint{
-			Name:    device.Hostname,
+			Name:    strings.Split(device.DeviceName, ".")[0],
 			Address: net.JoinHostPort(device.Addresses[0], "22"),
 		})
 	}
@@ -110,4 +111,5 @@ type device struct {
 	Addresses  []string `json:"addresses"`
 	Authorized bool     `json:"Authorized"`
 	Hostname   string   `json:"hostname"`
+	DeviceName string   `json:"name"`
 }


### PR DESCRIPTION
Tailscale nodes are more commonly known by their Tailscale device name, rather than the hostname. [Tailscale suggests using the device name/MagicDNS name too, to connect over SSH](https://tailscale.com/kb/1193/tailscale-ssh/#connect-over-ssh). This PR updates the displayed name to the device name for convenience.

| Before | After |
|--------|--------|
| <img width="1590" alt="image" src="https://github.com/charmbracelet/wishlist/assets/18581859/c8f61500-3be4-4a2e-8da6-fe1876032873"> | <img width="1590" alt="image" src="https://github.com/charmbracelet/wishlist/assets/18581859/f65a109d-15b2-46a8-9ca5-9498647e7902"> |