### PR TITLE
fix: handle errors on local mode

### DIFF
--- a/cmd/wishlist/main.go
+++ b/cmd/wishlist/main.go
@@ -53,7 +53,7 @@ It's also possible to serve the TUI over SSH using the server command.
 `,
 	Version:       Version,
 	SilenceUsage:  true,
-	SilenceErrors: true,
+	SilenceErrors: false,
 	Args:          cobra.MaximumNArgs(1),
 	CompletionOptions: cobra.CompletionOptions{
 		HiddenDefaultCmd: true,
@@ -123,10 +123,11 @@ var manCmd = &cobra.Command{
 }
 
 var serverCmd = &cobra.Command{
-	Use:     "serve",
-	Aliases: []string{"server", "s"},
-	Args:    cobra.NoArgs,
-	Short:   "Serve the TUI over SSH.",
+	Use:           "serve",
+	Aliases:       []string{"server", "s"},
+	Args:          cobra.NoArgs,
+	Short:         "Serve the TUI over SSH.",
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		seed, err := getSeedEndpoints(cmd.Context())
 		if err != nil {


### PR DESCRIPTION
closes #217

In server mode, we log the errors, so we don't need to print them again (hence `SilenceErrors`), but on local mode we don't log them, so we shouldn't silence errors in the case.