### PR TITLE
fix: do not make raw terminal on windows

### DIFF
--- a/client_local.go
+++ b/client_local.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"os/user"
 	"path/filepath"
+	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
@@ -117,16 +118,18 @@ func (s *localSession) Run() error {
 		}
 
 		log.Info("requesting tty")
-		originalState, err := term.MakeRaw(fd)
-		if err != nil {
-			return fmt.Errorf("failed get terminal state: %w", err)
-		}
-
-		defer func() {
-			if err := term.Restore(fd, originalState); err != nil {
-				log.Warn("couldn't restore terminal state", "err", err)
+		if runtime.GOOS != "windows" {
+			originalState, err := term.MakeRaw(fd)
+			if err != nil {
+				return fmt.Errorf("failed get terminal state: %w", err)
 			}
-		}()
+
+			defer func() {
+				if err := term.Restore(fd, originalState); err != nil {
+					log.Warn("couldn't restore terminal state", "err", err)
+				}
+			}()
+		}
 
 		w, h, err := term.GetSize(fd)
 		if err != nil {

--- a/client_unix.go
+++ b/client_unix.go
@@ -5,6 +5,7 @@ package wishlist
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,4 +36,18 @@ func (s *localSession) notifyWindowChanges(ctx context.Context, session *ssh.Ses
 			}
 		}
 	}
+}
+
+func makeRaw(fd int) (func(), error) {
+	log.Info("putting term in raw mode")
+	originalState, err := term.MakeRaw(fd)
+	if err != nil {
+		return func() {}, fmt.Errorf("failed get terminal state: %w", err)
+	}
+
+	return func() {
+		if err := term.Restore(fd, originalState); err != nil {
+			log.Warn("couldn't restore terminal state", "err", err)
+		}
+	}, nil
 }

--- a/client_windows.go
+++ b/client_windows.go
@@ -11,3 +11,7 @@ import (
 
 // not available because windows does not implement siscall.SIGWINCH.
 func (c *localSession) notifyWindowChanges(ctx context.Context, session *ssh.Session) {}
+
+func makeRaw(fd int) (func(), error) {
+	return func() {}, nil
+}


### PR DESCRIPTION
apparently windows does not handle it very well... and it seems to not be needed for windows either way.

closes #102