### PR TITLE
Fix: confirm search when pressing enter

### DIFF
--- a/wishlist.go
+++ b/wishlist.go
@@ -129,7 +129,7 @@ func (m *ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 		}
 		if key.Matches(msg, enter) {
-			if key.Matches(msg, keyO) && m.list.SettingFilter() {
+			if m.list.SettingFilter() {
 				break
 			}
 			selectedItem := m.list.SelectedItem()

--- a/wishlist.go
+++ b/wishlist.go
@@ -17,9 +17,6 @@ var (
 		key.WithKeys("enter", "o"),
 		key.WithHelp("enter/o", "connect"),
 	)
-	keyO = key.NewBinding(
-		key.WithKeys("o"),
-	)
 )
 
 // NewListing creates a new listing model for the given endpoints and SSH session.


### PR DESCRIPTION
This commit fixes an issue that occurred when confirming an initiated search. 
Pressing *enter* did not confirm the search, but executed the first item in the list.