### PR TITLE
fix: SetEnv when quoted value

### DIFF
--- a/sshconfig/parse.go
+++ b/sshconfig/parse.go
@@ -229,7 +229,7 @@ func parseInternal(r NamedReader) (*hostinfoMap, error) {
 				case "sendenv":
 					info.SendEnv = append(info.SendEnv, value)
 				case "setenv":
-					info.SetEnv = append(info.SetEnv, value)
+					info.SetEnv = append(info.SetEnv, parseSetEnv(value))
 				case "preferredauthentications":
 					info.PreferredAuthentications = append(info.PreferredAuthentications, strings.Split(value, ",")...)
 				case "include":
@@ -354,4 +354,17 @@ func parseFileInternal(path string) (*hostinfoMap, error) {
 	}
 	defer f.Close() //nolint:errcheck
 	return parseInternal(f)
+}
+
+func parseSetEnv(e string) string {
+	k, v, ok := strings.Cut(e, "=")
+	if !ok {
+		// just in case, do whatever we were doing before.
+		return e
+	}
+	qv, err := strconv.Unquote(v)
+	if err == nil {
+		return fmt.Sprintf("%s=%s", k, qv)
+	}
+	return fmt.Sprintf("%s=%s", k, v)
 }

--- a/sshconfig/parse_test.go
+++ b/sshconfig/parse_test.go
@@ -79,6 +79,7 @@ func TestParseFile(t *testing.T) {
 				},
 				SetEnv: []string{
 					"FOOS=foobar",
+					"FOO2=foobar within quotes",
 				},
 			},
 			"multiple3": {

--- a/sshconfig/testdata/good
+++ b/sshconfig/testdata/good
@@ -38,6 +38,7 @@ Host multiple2
 	Port 2223
 	ForwardAgent no
 	SetEnv FOOS=foobar
+	SetEnv FOO2="foobar within quotes"
 
 ##############
 # HOME STUFF #


### PR DESCRIPTION
This should work, and the quotes should be ignored.