### PR TITLE
Skip checking for identity files present in ~/.ssh/, if agent is started

### DIFF
--- a/client_auth.go
+++ b/client_auth.go
@@ -89,13 +89,13 @@ func localBestAuthMethod(agt agent.Agent, e *Endpoint, in io.Reader, out io.Writ
 
 			if method := agentAuthMethod(agt); method != nil {
 				methods = append(methods, method)
+			} else {
+				keys, err := tryUserKeys()
+				if err != nil {
+					return nil, err
+				}
+				methods = append(methods, keys...)
 			}
-
-			keys, err := tryUserKeys()
-			if err != nil {
-				return nil, err
-			}
-			methods = append(methods, keys...)
 		}
 	}
 


### PR DESCRIPTION
Skip checking for standard identity files present in ~/.ssh/, if ssh agent is started


-  I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- I have performed a self-review of my code

