### PR TITLE
fix(doc): config file emplacements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ The config files are tried in the following order:
 - `.wishlist/config.yaml`
 - `.wishlist/config.yml`
 - `.wishlist/config`
-- `[[user config dir]]/wishlist/config.yaml`[^1]
-- `[[user config dir]]/wishlist/config.yml`[^1]
-- `[[user config dir]]/wishlist/config`[^1]
+- `[[user config dir]]/wishlist.yaml`[^1]
+- `[[user config dir]]/wishlist.yml`[^1]
+- `[[user config dir]]/wishlist`[^1]
 - `$HOME/.ssh/config`
 - `/etc/ssh/ssh_config`
 


### PR DESCRIPTION
Apologize if I'm not right, but it seems to me that some of the config file emplacements described in the README are not right (those beginning with "[[user config dir]]") or at least non consistent with what's being outputted by `wishlist --help`:

```diff
Flags:
  -c, --config string                    Path to the config file to use. Defaults to, in order of preference: .wishlist/config.yaml, .wishlist/config.yml, .wishlist/config, 
+ /var/home/bleroux/.config/wishlist.yaml, 
+ /var/home/bleroux/.config/wishlist.yml, 
+ /var/home/bleroux/.config/wishlist, 
/var/home/bleroux/.ssh/config, /etc/ssh/ssh_config

```
while in the README it says the following:
```diff
+ [[user config dir]]/wishlist/config.yaml
+ [[user config dir]]/wishlist/config.yml
+ [[user config dir]]/wishlist/config
``` 

Note: I added line breaks and markdown diff format for better clarity

Running wishlist v0.15.2

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] ~~I have created a discussion that was approved by a maintainer (for new features).~~
